### PR TITLE
Add a double backslash for windows paths to load sketches

### DIFF
--- a/src/externals/sketches.js
+++ b/src/externals/sketches.js
@@ -8,10 +8,19 @@ const getSketches = globUrl => {
     glob.sync(globUrl + '/*').forEach(function (file) {
       const name = path.parse(file).name
       const url = path.resolve(file)
+      let indexUrl = path.format({ dir: url, base: 'index.js' })
+      let configUrl = path.format({ dir: url, base: 'config.js' })
+
+      if (indexUrl.indexOf('\\')) {
+        // For paths in Windows the next require function requires the path to have \\ as a separator instead of only \
+        indexUrl = indexUrl.replace(/\\/g, '\\\\')
+        configUrl = configUrl.replace(/\\/g, '\\\\')
+      }
+
       all[name] = {
         /*eslint-disable */
-        Module: eval('require("' + url + '/index.js")'),
-        config: eval('require("' + url + '/config.js")')
+        Module: eval('require("' + indexUrl + '")'),
+        config: eval('require("' + configUrl + '")')
         /*eslint-enable */
       }
     })


### PR DESCRIPTION
Tried to use the project but got an exception in the eval("require.... " looks like paths in windows need double backslashes