### PR TITLE
Added audio shaping sliders

### DIFF
--- a/src/components/AudioAnalyzer/index.js
+++ b/src/components/AudioAnalyzer/index.js
@@ -27,16 +27,15 @@ class AudioAnalyzer extends React.Component {
   componentWillUnmount () {
     uiEventEmitter.removeListener('slow-tick', this.draw)
   }
-  
+
   handleMouseDown (e) {
-    this.isOpen = !this.isOpen;
+    this.isOpen = !this.isOpen
     this.forceUpdate()
   }
 
   draw () {
     inputs = this.context.store.getState().inputs
     bands = [inputs.audio_0.value, inputs.audio_1.value, inputs.audio_2.value, inputs.audio_3.value]
-    
     this.drawGraph(bands)
   }
 
@@ -51,7 +50,7 @@ class AudioAnalyzer extends React.Component {
       val = data[ i ]
       height = this.height * val
       offset = this.height - height - 1
-      hue = i / data.length * 360  
+      hue = i / data.length * 360
 
       this.ctx.fillStyle = 'hsla(' + hue + ', 100%, 50%, 1)'
       this.ctx.fillRect(i * this.barWidth, offset, this.barWidth, height)
@@ -63,13 +62,13 @@ class AudioAnalyzer extends React.Component {
   render () {
     return (
       <div>
-      <canvas ref={node => { this.canvas = node }} 
-      onMouseDown={this.props.onMouseDown || this.handleMouseDown}
+        <canvas ref={node => { this.canvas = node }}
+          onMouseDown={this.props.onMouseDown || this.handleMouseDown}
       />
-      {this.isOpen &&
-        <div style={{position:"fixed"}}> 
-          <Control nodeId="audioNormalizeLevels" />
-          <Control nodeId="audioLevelsFalloff" />
+        {this.isOpen &&
+        <div style={{ position:'fixed' }}>
+          <Control nodeId='audioNormalizeLevels' />
+          <Control nodeId='audioLevelsFalloff' />
         </div>
       }
       </div>
@@ -79,6 +78,9 @@ class AudioAnalyzer extends React.Component {
 
 AudioAnalyzer.contextTypes = {
   store: PropTypes.object.isRequired
+}
+AudioAnalyzer.propTypes = {
+  onMouseDown: PropTypes.func
 }
 
 export default AudioAnalyzer

--- a/src/components/AudioAnalyzer/index.js
+++ b/src/components/AudioAnalyzer/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import uiEventEmitter from '../../utils/uiEventEmitter'
+import Control from '../../containers/Control'
 
 let height, val, offset, hue, i, inputs, bands
 
@@ -9,6 +10,8 @@ class AudioAnalyzer extends React.Component {
   constructor (props) {
     super(props)
     this.draw = this.draw.bind(this)
+    this.handleMouseDown = this.handleMouseDown.bind(this)
+    this.isOpen = false
   }
 
   componentDidMount () {
@@ -24,11 +27,16 @@ class AudioAnalyzer extends React.Component {
   componentWillUnmount () {
     uiEventEmitter.removeListener('slow-tick', this.draw)
   }
+  
+  handleMouseDown (e) {
+    this.isOpen = !this.isOpen;
+    this.forceUpdate()
+  }
 
   draw () {
     inputs = this.context.store.getState().inputs
     bands = [inputs.audio_0.value, inputs.audio_1.value, inputs.audio_2.value, inputs.audio_3.value]
-
+    
     this.drawGraph(bands)
   }
 
@@ -43,7 +51,7 @@ class AudioAnalyzer extends React.Component {
       val = data[ i ]
       height = this.height * val
       offset = this.height - height - 1
-      hue = i / data.length * 360
+      hue = i / data.length * 360  
 
       this.ctx.fillStyle = 'hsla(' + hue + ', 100%, 50%, 1)'
       this.ctx.fillRect(i * this.barWidth, offset, this.barWidth, height)
@@ -54,7 +62,17 @@ class AudioAnalyzer extends React.Component {
 
   render () {
     return (
-      <canvas ref={node => { this.canvas = node }} />
+      <div>
+      <canvas ref={node => { this.canvas = node }} 
+      onMouseDown={this.props.onMouseDown || this.handleMouseDown}
+      />
+      {this.isOpen &&
+        <div style={{position:"fixed"}}> 
+          <Control nodeId="audioNormalizeLevels" />
+          <Control nodeId="audioLevelsFalloff" />
+        </div>
+      }
+      </div>
     )
   }
 }

--- a/src/components/AudioAnalyzer/index.js
+++ b/src/components/AudioAnalyzer/index.js
@@ -2,8 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import uiEventEmitter from '../../utils/uiEventEmitter'
 import Control from '../../containers/Control'
+import styled from 'styled-components'
+import theme from '../../utils/theme'
 
 let height, val, offset, hue, i, inputs, bands
+
+const SettingsBox = styled.div`
+   background: ${theme.bgColorDark2};
+   position: absolute;
+`
 
 class AudioAnalyzer extends React.Component {
 
@@ -66,10 +73,10 @@ class AudioAnalyzer extends React.Component {
           onMouseDown={this.props.onMouseDown || this.handleMouseDown}
       />
         {this.isOpen &&
-        <div style={{ position:'fixed' }}>
+        <SettingsBox>
           <Control nodeId='audioNormalizeLevels' />
           <Control nodeId='audioLevelsFalloff' />
-        </div>
+        </SettingsBox>
       }
       </div>
     )

--- a/src/inputs/AudioAnalyzer.js
+++ b/src/inputs/AudioAnalyzer.js
@@ -9,6 +9,12 @@ class AudioInput {
     this.freqs = new Uint8Array(this.analyser.frequencyBinCount)
 
     this.levelsData = []
+    this.maxLevelsData = []
+    this.maxLevelFalloff = .9999
+    this.maxLevelMinimum = .001
+    for (let i = 0; i < this.numBands; i++) {
+      this.maxLevelsData[ i ] = this.maxLevelMinimum
+    }
 
     source.connect(this.analyser)
 
@@ -25,8 +31,11 @@ class AudioInput {
       for (let j = 0; j < this.levelBins; j++) {
         sum += this.freqs[ (i * this.levelBins) + j ]
       }
-
+      
       this.levelsData[ i ] = (sum / this.levelBins) / 256
+      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ] * this.maxLevelFalloff, this.maxLevelMinimum)
+      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ], this.levelsData[ i ])
+      this.levelsData[ i ] = this.levelsData[ i ] / this.maxLevelsData[ i ];      
     }
 
     return this.levelsData

--- a/src/inputs/AudioAnalyzer.js
+++ b/src/inputs/AudioAnalyzer.js
@@ -9,11 +9,15 @@ class AudioInput {
     this.freqs = new Uint8Array(this.analyser.frequencyBinCount)
 
     this.levelsData = []
-    this.maxLevelsData = []
-    this.maxLevelFalloff = .9999
-    this.maxLevelMinimum = .001
+    this.cleanLevelsData = []                 //storing the levels data before normalization so we dont get errors when using a low falloff
+    this.levelsFalloff = 1;                   //how much we reduce the clean bins value each frame, low numbers create a smoother release after sound bumps it up
+    this.normalizeLevels = 0;                 //blends between the pure volume and a normalized result
+    this.maxLevelsData = []                   //stores the highest value we have received for each bin
+    this.maxLevelFalloffMultiplier = .9999    //shaving a small amount off the max value each frame in case of a rare peak, quieter song, etc
+    this.maxLevelMinimum = .001               //stoping divide by zeros
     for (let i = 0; i < this.numBands; i++) {
       this.maxLevelsData[ i ] = this.maxLevelMinimum
+      this.levelsData[ i ] = this.cleanLevelsData[ i ] = 0
     }
 
     source.connect(this.analyser)
@@ -32,12 +36,15 @@ class AudioInput {
         sum += this.freqs[ (i * this.levelBins) + j ]
       }
       
-      this.levelsData[ i ] = (sum / this.levelBins) / 256
-      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ] * this.maxLevelFalloff, this.maxLevelMinimum)
-      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ], this.levelsData[ i ])
-      this.levelsData[ i ] = this.levelsData[ i ] / this.maxLevelsData[ i ];      
+      var band = (sum / this.levelBins) / 256
+      band = Math.max(band, Math.max(0, this.cleanLevelsData[ i ] - this.levelsFalloff));
+      this.cleanLevelsData[ i ] = band
+      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ] * this.maxLevelFalloffMultiplier, this.maxLevelMinimum)
+      this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ], band)
+      var normalized = band / this.maxLevelsData[ i ];
+      this.levelsData[ i ] =  (1 - this.normalizeLevels) * band + this.normalizeLevels * normalized;
     }
-
+    
     return this.levelsData
   }
 }

--- a/src/inputs/AudioAnalyzer.js
+++ b/src/inputs/AudioAnalyzer.js
@@ -9,12 +9,18 @@ class AudioInput {
     this.freqs = new Uint8Array(this.analyser.frequencyBinCount)
 
     this.levelsData = []
-    this.cleanLevelsData = []                 //storing the levels data before normalization so we dont get errors when using a low falloff
-    this.levelsFalloff = 1;                   //how much we reduce the clean bins value each frame, low numbers create a smoother release after sound bumps it up
-    this.normalizeLevels = 0;                 //blends between the pure volume and a normalized result
-    this.maxLevelsData = []                   //stores the highest value we have received for each bin
-    this.maxLevelFalloffMultiplier = .9999    //shaving a small amount off the max value each frame in case of a rare peak, quieter song, etc
-    this.maxLevelMinimum = .001               //stoping divide by zeros
+    // storing the levels data before normalization so we dont get errors when using a low falloff
+    this.cleanLevelsData = []
+    // how much we reduce the clean bins value each frame, low numbers create a smoother release after sound bumps it up
+    this.levelsFalloff = 1
+    // blends between the pure volume and a normalized result
+    this.normalizeLevels = 0
+    // stores the highest value we have received for each bin
+    this.maxLevelsData = []
+    // shaving a small amount off the max value each frame in case of a rare peak, quieter song, etc
+    this.maxLevelFalloffMultiplier = 0.9999
+    // stoping divide by zeros
+    this.maxLevelMinimum = 0.001
     for (let i = 0; i < this.numBands; i++) {
       this.maxLevelsData[ i ] = this.maxLevelMinimum
       this.levelsData[ i ] = this.cleanLevelsData[ i ] = 0
@@ -35,16 +41,16 @@ class AudioInput {
       for (let j = 0; j < this.levelBins; j++) {
         sum += this.freqs[ (i * this.levelBins) + j ]
       }
-      
+
       var band = (sum / this.levelBins) / 256
-      band = Math.max(band, Math.max(0, this.cleanLevelsData[ i ] - this.levelsFalloff));
+      band = Math.max(band, Math.max(0, this.cleanLevelsData[ i ] - this.levelsFalloff))
       this.cleanLevelsData[ i ] = band
       this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ] * this.maxLevelFalloffMultiplier, this.maxLevelMinimum)
       this.maxLevelsData[ i ] = Math.max(this.maxLevelsData[ i ], band)
-      var normalized = band / this.maxLevelsData[ i ];
-      this.levelsData[ i ] =  (1 - this.normalizeLevels) * band + this.normalizeLevels * normalized;
+      var normalized = band / this.maxLevelsData[ i ]
+      this.levelsData[ i ] = (1 - this.normalizeLevels) * band + this.normalizeLevels * normalized
     }
-    
+
     return this.levelsData
   }
 }

--- a/src/inputs/AudioInput.js
+++ b/src/inputs/AudioInput.js
@@ -1,32 +1,32 @@
 import AudioAnalyzer from './AudioAnalyzer'
 import { inputFired } from '../store/inputs/actions'
-import { uNodeCreate} from '../store/nodes/actions'
+import { uNodeCreate } from '../store/nodes/actions'
 
 export default (store) => {
   const gotStream = (stream) => {
     const input = new AudioAnalyzer(stream)
     const bandIds = ['audio_0', 'audio_1', 'audio_2', 'audio_3']
-    
-    store.dispatch(uNodeCreate("audioNormalizeLevels", {
-      title: "Normalize Levels",
+
+    store.dispatch(uNodeCreate('audioNormalizeLevels', {
+      title: 'Normalize Levels',
       type: 'param',
       key: 'normalizeLevels',
       value: input.normalizeLevels,
-      id: "audioNormalizeLevels"
+      id: 'audioNormalizeLevels'
     }))
 
-    store.dispatch(uNodeCreate("audioLevelsFalloff", {
-        title: "Levels Falloff",
-        type: 'param',
-        key: 'levelsFalloff',
-        value: input.levelsFalloff,
-        id: "audioLevelsFalloff"
-      }))
-    
+    store.dispatch(uNodeCreate('audioLevelsFalloff', {
+      title: 'Levels Falloff',
+      type: 'param',
+      key: 'levelsFalloff',
+      value: input.levelsFalloff,
+      id: 'audioLevelsFalloff'
+    }))
+
     let bands, i
     window.setInterval(() => {
-      input.normalizeLevels = store.getState().nodes["audioNormalizeLevels"].value
-      input.levelsFalloff = Math.pow(store.getState().nodes["audioLevelsFalloff"].value, 2)
+      input.normalizeLevels = store.getState().nodes['audioNormalizeLevels'].value
+      input.levelsFalloff = Math.pow(store.getState().nodes['audioLevelsFalloff'].value, 2)
       bands = input.update()
       for (i = 0; i < bands.length; i++) {
         store.dispatch(inputFired(bandIds[i], bands[i], { type: 'audio' }))

--- a/src/inputs/AudioInput.js
+++ b/src/inputs/AudioInput.js
@@ -10,7 +10,6 @@ export default (store) => {
     store.dispatch(uNodeCreate('audioNormalizeLevels', {
       title: 'Normalize Levels',
       type: 'param',
-      key: 'normalizeLevels',
       value: input.normalizeLevels,
       id: 'audioNormalizeLevels'
     }))
@@ -18,7 +17,6 @@ export default (store) => {
     store.dispatch(uNodeCreate('audioLevelsFalloff', {
       title: 'Levels Falloff',
       type: 'param',
-      key: 'levelsFalloff',
       value: input.levelsFalloff,
       id: 'audioLevelsFalloff'
     }))

--- a/src/inputs/AudioInput.js
+++ b/src/inputs/AudioInput.js
@@ -1,13 +1,32 @@
 import AudioAnalyzer from './AudioAnalyzer'
 import { inputFired } from '../store/inputs/actions'
+import { uNodeCreate} from '../store/nodes/actions'
 
 export default (store) => {
   const gotStream = (stream) => {
     const input = new AudioAnalyzer(stream)
     const bandIds = ['audio_0', 'audio_1', 'audio_2', 'audio_3']
+    
+    store.dispatch(uNodeCreate("audioNormalizeLevels", {
+      title: "Normalize Levels",
+      type: 'param',
+      key: 'normalizeLevels',
+      value: input.normalizeLevels,
+      id: "audioNormalizeLevels"
+    }))
 
+    store.dispatch(uNodeCreate("audioLevelsFalloff", {
+        title: "Levels Falloff",
+        type: 'param',
+        key: 'levelsFalloff',
+        value: input.levelsFalloff,
+        id: "audioLevelsFalloff"
+      }))
+    
     let bands, i
     window.setInterval(() => {
+      input.normalizeLevels = store.getState().nodes["audioNormalizeLevels"].value
+      input.levelsFalloff = Math.pow(store.getState().nodes["audioLevelsFalloff"].value, 2)
       bands = input.update()
       for (i = 0; i < bands.length; i++) {
         store.dispatch(inputFired(bandIds[i], bands[i], { type: 'audio' }))


### PR DESCRIPTION
show/hide the sliders by clicking the spectrum preview

normalize slider is useful when working with a low volume feed, stores the maximum value it has received for each bin and adjusts the output acordingly to fill the full 0-1 range

falloff slider creates a slow release after the level peaks above the current value, slider is the amount it reduces each frame (value of 1 reduces fully, effectively turning it off)