### PR TITLE
Fixed macro editing title bug

### DIFF
--- a/src/containers/ParamBar/index.js
+++ b/src/containers/ParamBar/index.js
@@ -3,7 +3,6 @@ import ValueBar from '../../components/ValueBar'
 import { nodeValueUpdate } from '../../store/nodes/actions'
 import getNode from '../../selectors/getNode'
 import getInputLink from '../../selectors/getInputLink'
-import getUiIsEditingNode from '../../selectors/getUiIsEditingNode'
 import getIsEditing from '../../selectors/getIsEditing'
 import { uiEditingOpen } from '../../store/ui/actions'
 

--- a/src/containers/ParamBar/index.js
+++ b/src/containers/ParamBar/index.js
@@ -4,6 +4,7 @@ import { nodeValueUpdate } from '../../store/nodes/actions'
 import getNode from '../../selectors/getNode'
 import getInputLink from '../../selectors/getInputLink'
 import getUiIsEditingNode from '../../selectors/getUiIsEditingNode'
+import getIsEditing from '../../selectors/getIsEditing'
 import { uiEditingOpen } from '../../store/ui/actions'
 
 const mapStateToProps = (state, ownProps) => {
@@ -12,13 +13,12 @@ const mapStateToProps = (state, ownProps) => {
   const linkId = node.activeInputLinkId
   const inputLink = getInputLink(state, linkId)
   const hideBar = type === 'shot' && (!inputLink || inputLink && inputLink.input.type !== 'audio')
-  const editingNode = getUiIsEditingNode(state)
 
   return {
     type,
     hideBar,
     markerIsVisible: type === 'shot' && !hideBar && inputLink.armed,
-    formIsVisible: editingNode && editingNode.id === ownProps.nodeId
+    formIsVisible: getIsEditing(state, ownProps.nodeId, 'paramValue')
   }
 }
 

--- a/src/selectors/_test/getIsEditing.spec.js
+++ b/src/selectors/_test/getIsEditing.spec.js
@@ -1,0 +1,57 @@
+import test from 'tape'
+import getIsEditing from '../getIsEditing'
+
+test('(Selector) getIsEditing - not editing', (t) => {
+  let actual
+
+  const state = {
+    ui: {
+      isEditing: false
+    }
+  }
+
+  actual = getIsEditing(state, 'XXX')
+  t.deepEqual(actual, false, 'Returns false')
+
+  t.end()
+})
+
+test('(Selector) getIsEditing - editing type doesnt match', (t) => {
+  let actual
+
+  const state = {
+    ui: {
+      isEditing: {
+        id: 'XXX',
+        type: 'fooType'
+      }
+    }
+  }
+
+  actual = getIsEditing(state, 'XXX', 'barType')
+  t.deepEqual(actual, false, 'Returns false when ID matches')
+
+  actual = getIsEditing(state, 'YYY', 'barType')
+  t.deepEqual(actual, false, 'Returns false when ID doesn\'t match')
+  t.end()
+})
+
+test('(Selector) getIsEditing - editing type does match', (t) => {
+  let actual
+
+  const state = {
+    ui: {
+      isEditing: {
+        id: 'XXX',
+        type: 'fooType'
+      }
+    }
+  }
+
+  actual = getIsEditing(state, 'XXX', 'fooType')
+  t.deepEqual(actual, true, 'Returns true when ID matches')
+
+  actual = getIsEditing(state, 'YYY', 'fooType')
+  t.deepEqual(actual, false, 'Returns false when ID doesn\'t match')
+  t.end()
+})

--- a/src/selectors/getIsEditing.js
+++ b/src/selectors/getIsEditing.js
@@ -1,0 +1,7 @@
+export default (state, id, type) => {
+  const isEditing = state.ui.isEditing
+
+  return isEditing &&
+    isEditing.id === id &&
+    isEditing.type === type
+}


### PR DESCRIPTION
Macro editing title form was instantly closing after opening. This was because at the same time, the form for the param value was also opening. Using the isEditing.type property to distinguish between both editing types.