### PR TITLE
Added key prop to MenuPanel so that it unmounts when the param changes

### DIFF
--- a/src/components/PropertiesPanel/index.js
+++ b/src/components/PropertiesPanel/index.js
@@ -55,7 +55,7 @@ const PropertiesPanel = ({ isOpen, nodeId, Component, onCloseClick, panelId, tit
   return (
     <PanelContext.Provider value={panelId}>
       {isOpen &&
-      <MenuPanel titleContent={titleContent} onCloseClick={onCloseClick}>
+      <MenuPanel titleContent={titleContent} onCloseClick={onCloseClick} key={nodeId}>
         <Component nodeId={nodeId} />
       </MenuPanel>
     }


### PR DESCRIPTION
Fixes https://github.com/nudibranchrecords/hedron/issues/208

The issue was that redux-form needs to unmount and remount to update the values in the form. Since changing the design so that the properties for each param appear in the same place, it wasn't unmounting. To fix this, we just need a unique `key` prop to change in the parent component to force the unmounting.