### PR TITLE
Added "allowed types" for macro learn node values

### DIFF
--- a/src/store/macros/utils.js
+++ b/src/store/macros/utils.js
@@ -1,6 +1,12 @@
 import isInputTypeHuman from '../../utils/isInputTypeHuman'
 
+// TODO: Boolean not yet supported type of node value
+// but putting in for future's sake
+const allowedTypes = ['number', 'boolean']
+
 export const shouldItLearn = (learningId, node, payload) => {
+  if (!allowedTypes.includes(typeof node.value)) return false
+
   const pType = payload.meta && payload.meta.type
   if (pType && (!isInputTypeHuman(pType) || pType === 'macro')) {
     return false


### PR DESCRIPTION
Fixes https://github.com/nudibranchrecords/hedron/issues/227

We now have an "allowed types" array for incoming values that might want to be learnt by a macro. Currently this is set to `number` and `boolean`, even though we don't have boolean values yet, will do eventually.