### PR TITLE
Better handling of when nodes return undefined 

### DIFF
--- a/src/selectors/getNode.js
+++ b/src/selectors/getNode.js
@@ -1,1 +1,9 @@
-export default (state, nodeId) => state.nodes[nodeId]
+export default (state, nodeId) => {
+  if (!nodeId) return undefined
+
+  const node = state.nodes[nodeId]
+  if (node === undefined) {
+    console.warn(`[HEDRON] getNode() couldn't find node for nodeId ${nodeId}`)
+  }
+  return node
+}

--- a/src/selectors/getNodeAncestors.js
+++ b/src/selectors/getNodeAncestors.js
@@ -5,8 +5,11 @@ export default (state, nodeId) => {
 
   const addNode = nodeId => {
     const node = getNode(state, nodeId)
-    arr.push(node)
-    if (node.parentNodeId) addNode(node.parentNodeId)
+
+    if (node !== undefined) {
+      arr.push(node)
+      if (node.parentNodeId) addNode(node.parentNodeId)
+    }
   }
 
   addNode(nodeId)


### PR DESCRIPTION
for `getNode` and `getNodeAncestors` selectors

Fixes https://github.com/nudibranchrecords/hedron/issues/225