### PR TITLE
Rehydrating state without any midi device edits and using processDevices instead

### DIFF
--- a/src/inputs/MidiInput.js
+++ b/src/inputs/MidiInput.js
@@ -6,81 +6,86 @@ import { newData as teachMidi } from '../utils/getMidiMode'
 import { processMidiData } from '../utils/midiMessage'
 import getConnectedDevice from '../selectors/getConnectedDevice'
 
-export default (store) => {
-  const onMessage = (rawMessage) => {
-    const state = store.getState()
-    const deviceId = rawMessage.target.name
+let store, midiAccess
 
-    const device = getConnectedDevice(state, deviceId)
-    const m = processMidiData(rawMessage.data, device.settings.forceChannel.value)
+const onMessage = (rawMessage) => {
+  const state = store.getState()
+  const deviceId = rawMessage.target.name
 
-    if (m.messageType !== 'timingClock' && m.messageType !== 'noteOff') {
-      store.dispatch(midiMessage(deviceId, {
-        data: rawMessage.data,
-        timeStamp: rawMessage.timeStamp,
-      }))
+  const device = getConnectedDevice(state, deviceId)
+  const m = processMidiData(rawMessage.data, device.settings.forceChannel.value)
 
-      const learning = state.midi.learning
+  if (m.messageType !== 'timingClock' && m.messageType !== 'noteOff') {
+    store.dispatch(midiMessage(deviceId, {
+      data: rawMessage.data,
+      timeStamp: rawMessage.timeStamp,
+    }))
 
-      if (learning) {
-        let controlType
-        const mode = teachMidi(rawMessage.data, m.messageType)
+    const learning = state.midi.learning
 
-        if (mode !== 'learning') {
-          if (mode === 'ignore') {
-            controlType = undefined
-          } else {
-            // abs, rel1, rel2, rel3
-            controlType = mode
-          }
-          store.dispatch(uInputLinkCreate(
-            learning.id,
-            m.id,
-            learning.type,
-            {
-              controlType,
-              channel: m.channel,
-              messageType: m.messageType,
-              noteNum: m.noteNum,
-            }
-          ))
-          store.dispatch(midiStopLearning())
+    if (learning) {
+      let controlType
+      const mode = teachMidi(rawMessage.data, m.messageType)
+
+      if (mode !== 'learning') {
+        if (mode === 'ignore') {
+          controlType = undefined
+        } else {
+          // abs, rel1, rel2, rel3
+          controlType = mode
         }
-      } else {
-        store.dispatch(inputFired(m.id, m.value, {
-          noteOn: m.messageType === 'noteOn',
-          type: 'midi',
-        }))
+        store.dispatch(uInputLinkCreate(
+          learning.id,
+          m.id,
+          learning.type,
+          {
+            controlType,
+            channel: m.channel,
+            messageType: m.messageType,
+            noteNum: m.noteNum,
+          }
+        ))
+        store.dispatch(midiStopLearning())
       }
-    // If no note data, treat as clock
-    } else if (m.messageType === 'timingClock') {
-      // Only dispatch clock pulse if no generated clock
-      if (!state.clock.isGenerated) {
-        store.dispatch(clockPulse())
-      }
+    } else {
+      store.dispatch(inputFired(m.id, m.value, {
+        noteOn: m.messageType === 'noteOn',
+        type: 'midi',
+      }))
+    }
+  // If no note data, treat as clock
+  } else if (m.messageType === 'timingClock') {
+    // Only dispatch clock pulse if no generated clock
+    if (!state.clock.isGenerated) {
+      store.dispatch(clockPulse())
     }
   }
+}
 
-  const processDevices = ports => {
-    const devices = {}
+export const processDevices = () => {
+  const devices = {}
 
-    ports.forEach((entry) => {
-      devices[entry.name] = {
-        title: entry.name,
-        id: entry.name,
-        manufacturer: entry.manufacturer,
-      }
-      entry.onmidimessage = onMessage
-    })
+  midiAccess.inputs.forEach((entry) => {
+    devices[entry.name] = {
+      title: entry.name,
+      id: entry.name,
+      manufacturer: entry.manufacturer,
+    }
+    entry.onmidimessage = onMessage
+  })
 
-    store.dispatch(midiUpdateDevices(devices))
-  }
+  store.dispatch(midiUpdateDevices(devices))
+}
 
-  navigator.requestMIDIAccess().then((midiAccess) => {
-    processDevices(midiAccess.inputs)
+export default (injectedStore) => {
+  store = injectedStore
+
+  navigator.requestMIDIAccess().then((injectedMidiAccess) => {
+    midiAccess = injectedMidiAccess
+    processDevices()
 
     midiAccess.onstatechange = () => {
-      processDevices(midiAccess.inputs)
+      processDevices()
     }
   })
 }

--- a/src/store/midi/reducer.js
+++ b/src/store/midi/reducer.js
@@ -66,7 +66,10 @@ const midiReducer = (state = defaultState, action) => {
           ...state.devices,
           [p.id]: {
             ...state.devices[p.id],
-            settings: p.values,
+            settings: {
+              ...state.devices[p.id].settings,
+              ...p.values,
+            },
           },
         },
       }

--- a/src/store/project/sagas.js
+++ b/src/store/project/sagas.js
@@ -10,6 +10,7 @@ import { projectLoadSuccess, projectRehydrate, projectError, projectSaveAs,
 import { uSceneCreate } from '../scenes/actions'
 import history from '../../history'
 import { remote } from 'electron'
+import { processDevices } from '../../inputs/MidiInput'
 
 const fileFilters = [
   { name: 'JSON', extensions: ['json'] },
@@ -58,6 +59,7 @@ export function* loadProjectRequest () {
     const filepath = yield select(getProjectFilepath)
     const projectData = yield call(load, filepath)
     yield put(projectRehydrate(projectData))
+    yield call(processDevices)
     yield put(projectFilepathUpdate(filepath))
     yield put(projectLoadSuccess(projectData))
     yield call([history, history.replace], projectData.router.location.pathname)

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -49,14 +49,6 @@ const rootReducer = (state = {}, action) => action.type === 'PROJECT_REHYDRATE'
   ? {
     ...state,
     ...action.payload.data,
-    ...{
-      midi: {
-        ...action.payload.data.midi,
-        // make sure connected midi devices are kept the same as before the project load
-        connectedDeviceIds: state.midi.connectedDeviceIds,
-        learning: false,
-      },
-    },
   }
   : reducers(state, action)
 


### PR DESCRIPTION
Fixes a bug where app was crashing if device was connected to machine and loaded a project where it didn't exist on the list. Could have updated the rehydrating logic but seems more robust to simply call `processDevices` again and let the reducer handle this logic (as it already is doing). Too many edge cases to be handling this in two places. 