### PR TITLE
Fixed proptype error

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -143,7 +143,7 @@ Select.propTypes = {
       label: PropTypes.oneOfType([
         PropTypes.string, PropTypes.number,
       ]).isRequired,
-    }).isRequired,
+    }),
     onChange: PropTypes.func.isRequired,
   }).isRequired,
 }


### PR DESCRIPTION
Fixes https://github.com/nudibranchrecords/hedron/issues/344

There were two options, either add an empty value object to meet the `required` prop, or just stop that prop from being required. I went for the latter, as clearly a `Select` doesn't always have to have a value.