### PR TITLE
Custom sketch render methods.

### DIFF
--- a/src/engine/Scene.js
+++ b/src/engine/Scene.js
@@ -5,6 +5,7 @@ class Scene {
     this.scene = new THREE.Scene()
     this.camera = new THREE.PerspectiveCamera(75, null, 1, 100000)
     this.camera.position.z = 5
+    this.renderMethods = new Map()
   }
 
   setRatio (ratio) {

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -152,6 +152,7 @@ export const addSketchToScene = (sceneId, sketchId, moduleId, shouldSetPost = tr
 
   sketches[sketchId] = module
   module.root && scene.scene.add(module.root)
+  module.render && scene.renderMethods.set(sketchId, module.render.bind(module))
 
   if (shouldSetPost) renderer.setPostProcessing()
 }
@@ -161,6 +162,9 @@ export const removeSketchFromScene = (sceneId, sketchId, shouldSetPost) => {
   const sketch = sketches[sketchId]
 
   scenes[sceneId].scene.remove(sketch.root)
+  if (sketch.render) {
+    scenes[sceneId].renderMethods.delete(sketchId)
+  }
 
   if (sketch.destructor) {
     sketch.destructor({


### PR DESCRIPTION
This PR explores custom render methods per sketch, which allow sketches to have full control of the render loop (through the custom ``CallbackPass``, instead of running a simple ``RenderPass``).

Work needs to be done in the following areas:
- Pass depth and stencil buffers to these passes.
- Make sure the screen buffers are not cleared between ``CallbackPasses`` (unless you're explicitly doing it so inside the render callback).
- Render order: Should these be rendered before or after the main ``RenderPass``? 
  - How should the render order be defined if you have sth like this?
    - SCENE
      - RootSketch
      - RenderSketch
      - RootSketch
      - RenderSketch

Hopefully we can figure out these details together ;)