### PR TITLE
Add randomize scene sketches button

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -123,10 +123,13 @@ This is the main file for the sketch. Essentially, it's a Javascript class, with
   - `allParams` - A key/value pair of all the sketches in the scene, aech with their own key/value pair of params
   - `outputSize` - An object with `width` and `height` properties that match the image output resolution
 - `destructor` - Fires when a sketch is removed. Use this to clean up anything that may continue to run afterwards. Not usually needed. Has the same argument object as the construtor, except for the `params` property.
+  `randomize` - If a function exists, and is setup as a [shot](#shots) in the config, it will be called when a scenes `Randomize` button is clicked or triggered.
 
 ### Shots
 Any custom method in your sketch class can be defined as a shot in the config. Shot methods have a single object literal as an argument, with the following properties:
 - `params` - A key/value pair of all the params in the sketch
+
+Shots can optionally return a partial key/value pair of sketch params, where the values are normalized 0-1. Doing so will apply that value to the slider.
 
 ### Global HEDRON variable
 Hedron provides a single global variable with some useful libraries to make use of.

--- a/src/components/SceneManager/index.js
+++ b/src/components/SceneManager/index.js
@@ -43,7 +43,7 @@ const ActionButton = (props) => (
 const SceneManager = (
   {
     currentScene, onDeleteClick, onRenameClick, onChannelClick,
-    onClearClick, onActiveClick, onOppositeClick,
+    onClearClick, onActiveClick, onOppositeClick, onRandomClick
   }
 ) => {
   const la = currentScene && currentScene.linkableActionIds
@@ -97,6 +97,15 @@ const SceneManager = (
             Clear
           </ActionButton>
 
+            <ActionButton
+              onClick={() => { onRandomClick(currentScene.id) }}
+              linkableActionId={la.randomize}
+              panelId='overview'
+            >
+              Randomize
+            </ActionButton>
+
+
           <Col>
             <Button
               onClick={e => {
@@ -124,6 +133,7 @@ SceneManager.propTypes = {
   onClearClick: PropTypes.func.isRequired,
   onActiveClick: PropTypes.func.isRequired,
   onOppositeClick: PropTypes.func.isRequired,
+  onRandomClick: PropTypes.func.isRequired,
 }
 
 export default SceneManager

--- a/src/containers/SceneManager/index.js
+++ b/src/containers/SceneManager/index.js
@@ -3,7 +3,7 @@ import SceneManager from '../../components/SceneManager'
 import getCurrentScene from '../../selectors/getCurrentScene'
 import getCurrentSceneId from '../../selectors/getCurrentSceneId'
 import {
-  uSceneDelete, uSceneSelectChannel, sceneClearChannel,
+  uSceneDelete, uSceneSelectChannel, sceneClearChannel, uSceneRandomize,
 }
   from '../../store/scenes/actions'
 import { uiEditingOpen } from '../../store/ui/actions'
@@ -31,6 +31,9 @@ const mapDispatchToProps = (dispatch, ownProps) => (
     },
     onChannelClick: (sceneId, channel) => {
       dispatch(uSceneSelectChannel(sceneId, channel))
+    },
+    onRandomClick: (sceneId) => {
+      dispatch(uSceneRandomize(sceneId))
     },
   }
 )

--- a/src/store/scenes/actions.js
+++ b/src/store/scenes/actions.js
@@ -53,6 +53,11 @@ export function sceneRename (id, title) {
   }
 }
 
+export const uSceneRandomize = (id) => ({
+  type: 'U_SCENE_RANDOMIZE',
+  payload: { id },
+})
+
 export function uSceneDelete (id) {
   return {
     type: 'U_SCENE_DELETE',

--- a/src/store/scenes/listener.js
+++ b/src/store/scenes/listener.js
@@ -161,6 +161,18 @@ const handleSceneSettingsUpdate = (action, store) => {
   setPostProcessing()
 }
 
+const handleSceneRandomize = (action, store) => {
+  const p = action.payload
+  const scene = store.getState().scenes.items[p.id]
+  if (!scene) {
+    console.warn('Scene not found, skipping randomize', p.id)
+    return
+  }
+  scene.sketchIds.forEach(sketchId => {
+    engine.fireShot(sketchId, 'randomize')
+  });
+}
+
 export default (action, store) => {
   switch (action.type) {
     case 'U_SCENE_CREATE':
@@ -189,6 +201,9 @@ export default (action, store) => {
       break
     case 'SCENE_CLEAR_CHANNEL':
       handleSceneClearChannel(action, store)
+      break
+    case 'U_SCENE_RANDOMIZE':
+      handleSceneRandomize(action, store)
       break
   }
 }

--- a/src/store/scenes/utils.js
+++ b/src/store/scenes/utils.js
@@ -1,5 +1,5 @@
 import uid from 'uid'
-import { uSceneSelectChannel, sceneClearChannel } from './actions'
+import { uSceneSelectChannel, sceneClearChannel, uSceneRandomize } from './actions'
 
 export const generateSceneLinkableActionIds = id => ({
   addToA: {
@@ -26,5 +26,10 @@ export const generateSceneLinkableActionIds = id => ({
     action: sceneClearChannel(id),
     id: uid(),
     title: 'Clear',
+  },
+  randomize: {
+    action: uSceneRandomize(id),
+    id: uid(),
+    title: 'Call Randomize',
   },
 })


### PR DESCRIPTION
Add a midi-assignable button to attempt to call the `randomize` shot on all sketches in a scene

![image](https://github.com/nudibranchrecords/hedron/assets/4506708/01571e3b-bfdd-4185-abb6-ae2a1308a612)
