### PR TITLE
Basic Post Processing

### DIFF
--- a/example-project/sketches/hsl/hsl.js
+++ b/example-project/sketches/hsl/hsl.js
@@ -1,0 +1,66 @@
+export default `
+
+uniform sampler2D u_texture;
+uniform vec3 u_hsl;  // Hue, saturation, lightness adjustments
+varying vec2 vUv;
+
+// Function to convert an RGB color to HSL
+vec3 rgb2hsl(vec3 color) {
+    float maxC = max(max(color.r, color.g), color.b);
+    float minC = min(min(color.r, color.g), color.b);
+    float l = (maxC + minC) / 2.0;
+    if (maxC == minC) {
+        return vec3(0.0, 0.0, l);
+    } else {
+        float h = 0.0;
+        float s = 0.0;
+        if (l < 0.5) s = (maxC - minC) / (maxC + minC);
+        else s = (maxC - minC) / (2.0 - maxC - minC);
+        if (color.r == maxC) h = (color.g - color.b) / (maxC - minC);
+        else if (color.g == maxC) h = 2.0 + (color.b - color.r) / (maxC - minC);
+        else h = 4.0 + (color.r - color.g) / (maxC - minC);
+        h /= 6.0;
+        if (h < 0.0) h += 1.0;
+        return vec3(h, s, l);
+    }
+}
+
+// Function to convert an HSL color to RGB
+vec3 hsl2rgb(vec3 color) {
+    if (color.y == 0.0) {
+        return vec3(color.z);
+    } else {
+        float q = 0.0;
+        if (color.z < 0.5) q = color.z * (1.0 + color.y);
+        else q = color.z + color.y - color.y * color.z;
+        float p = 2.0 * color.z - q;
+        float hk = color.x;
+        vec3 tc = vec3(hk + 1.0/3.0, hk, hk - 1.0/3.0);
+        vec3 result;
+        for(int i=0; i<3; i++) {
+            if (tc[i] < 0.0) tc[i] += 1.0;
+            if (tc[i] > 1.0) tc[i] -= 1.0;
+            if (tc[i] < 1.0/6.0) result[i] = p + ((q - p) * 6.0 * tc[i]);
+            else if (tc[i] < 0.5) result[i] = q;
+            else if (tc[i] < 2.0/3.0) result[i] = p + ((q - p) * 6.0 * (2.0/3.0 - tc[i]));
+            else result[i] = p;
+        }
+        return result;
+    }
+}
+
+void main() {
+    vec4 texColor = texture2D(u_texture, vUv);
+    vec3 hsl = rgb2hsl(texColor.rgb);
+
+    // Apply HSL adjustments
+    hsl.x += u_hsl.x;  // Hue
+    hsl.y *= u_hsl.y;  // Saturation
+    hsl.z *= u_hsl.z;  // Lightness
+
+    // Convert back to RGB
+    vec3 rgb = hsl2rgb(hsl);
+
+    gl_FragColor = vec4(rgb, 1.0);
+}
+`;

--- a/example-project/sketches/hsl/index.ts
+++ b/example-project/sketches/hsl/index.ts
@@ -1,0 +1,102 @@
+import { EffectPass, SavePass, CopyPass, Pass, ShaderPass } from 'postprocessing'
+import { Uniform, Texture, Scene, Camera, WebGLRenderer, WebGLRenderTarget, ShaderMaterial, Vector3 } from 'three';
+
+import fragmentShader from './hsl.js';
+
+/**
+ * A basic post proicessing effect to adjust the hue, saturation, and lightness of the scene.
+ * While this could be created with existing postprocessing passes, this example demonstrates how to create a custom effect.
+ */
+export default class HSL {
+  shader: ShaderMaterial;
+  pass: ShaderPass;
+  passes:Pass[]
+
+  /**
+   * Gets the passes for this effect.
+   * This function is called by Hedron to get the passes for this effect.
+   * Passes are added to the scenes EffectComposer
+   * This function is currently called every frame, so be sure to cache the passes.
+   * You can also modify the pass list at any time, and Hedron will update the scene accordingly.
+   */
+  getPasses(): Pass[] {
+    if(!this.passes){
+      this.createPasses()
+    }
+    return this.passes
+  }
+
+  createPasses(){
+    this.shader = this.createBloom()
+    this.pass = new ShaderPass(this.shader, 'u_texture')
+    this.passes = [
+      this.pass
+    ]
+  }
+
+  createBloom(): ShaderMaterial {
+    const uniforms = [
+      ['u_hsl', new Uniform(new Vector3(0.0, 1.0, 1.0))],
+      ['u_texture', new Uniform(Texture)],
+    ];
+
+    return new ShaderMaterial({
+        uniforms: Object.fromEntries(uniforms),
+        vertexShader: `
+		varying vec2 vUv;
+		void main() {
+		    vUv = uv;
+		    gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+	    }`,
+        fragmentShader,
+    })
+  }
+
+  /**
+   * Called by Hedron every frame with the current parameters.
+   */
+  update({ params }) {
+    this.setUniform('u_hsl', new Vector3(params.hue, params.saturation, params.lightness))
+  }
+
+  setUniform(key: string, value: any) {
+    if (this.shader.uniforms[key]) {
+      this.shader.uniforms[key].value = value;
+    }
+  }
+
+  /**
+   * The function can be used instead of a seperate config.js/ts file
+   * @returns The configuration for this effect.
+   */
+  getConfig() {
+    return {
+        title: 'HSL',
+        description: 'Hue, Saturation, Lightness',
+        category: 'simple',
+        params: [
+            {
+                title: 'Hue',
+                key: 'hue',
+                defaultValue: 0.0,
+                defaultMin: 0.0,
+                defaultMax: 1.0,
+            },
+            {
+                title: 'Saturation',
+                key: 'saturation',
+                defaultValue: 1.0,
+                defaultMin: 0.0,
+                defaultMax: 1.0,
+            },
+            {
+                title: 'Lightness',
+                key: 'lightness',
+                defaultValue: 1.0,
+                defaultMin: 0.0,
+                defaultMax: 1.0,
+            },
+        ],
+    }
+  }
+}

--- a/src/engine/HedronEngine.ts
+++ b/src/engine/HedronEngine.ts
@@ -78,8 +78,7 @@ export class HedronEngine {
   }
 
   run() {
-    const debugScene = createDebugScene(this.renderer.aspectRatio)
-    debugScene.renderer = this.renderer.composer?.getRenderer()
+    const debugScene = createDebugScene(this.renderer)
 
     const loop = (): void => {
       const { sketches, nodeValues, nodes } = this.store.getState()

--- a/src/engine/HedronEngine.ts
+++ b/src/engine/HedronEngine.ts
@@ -79,11 +79,12 @@ export class HedronEngine {
 
   run() {
     const debugScene = createDebugScene(this.renderer.aspectRatio)
+    debugScene.renderer = this.renderer.composer?.getRenderer()
 
     const loop = (): void => {
       const { sketches, nodeValues, nodes } = this.store.getState()
       const sketchInstances = this.sketchManager!.getSketchInstances()
-
+      debugScene.clearPasses()
       Object.values(sketches).forEach((sketch) => {
         // eslint-disable-next-line
         const paramValues: { [key: string]: any } = {}
@@ -94,7 +95,14 @@ export class HedronEngine {
           paramValues[paramKey] = value
         })
 
-        sketchInstances[sketch.id].update({ deltaFrame: 1, params: paramValues })
+        const instance = sketchInstances[sketch.id]
+
+        if (instance.getPasses) {
+          instance.getPasses(debugScene).forEach((pass) => {
+            debugScene.addPass(pass)
+          })
+        }
+        instance.update({ deltaFrame: 1, params: paramValues })
       })
 
       requestAnimationFrame(loop)

--- a/src/engine/world/EngineScene.ts
+++ b/src/engine/world/EngineScene.ts
@@ -5,14 +5,15 @@ export class EngineScene {
   public scene: Scene
   public camera: PerspectiveCamera
   public passes: Pass[]
+  private renderPass: RenderPass
   public renderer: WebGLRenderer
 
   constructor() {
     this.scene = new Scene()
     this.camera = new PerspectiveCamera(75, undefined, 0.1, 100000)
     this.camera.position.z = 5
-    const renderPass = new RenderPass(this.scene, this.camera)
-    this.passes = [renderPass]
+    this.renderPass = new RenderPass(this.scene, this.camera)
+    this.passes = [this.renderPass]
   }
 
   setRatio(ratio: number): void {
@@ -25,6 +26,6 @@ export class EngineScene {
   }
 
   clearPasses(): void {
-    this.passes = [this.passes[0]]
+    this.passes = [this.renderPass]
   }
 }

--- a/src/engine/world/EngineScene.ts
+++ b/src/engine/world/EngineScene.ts
@@ -1,17 +1,30 @@
-import { PerspectiveCamera, Scene } from 'three'
+import { Pass, RenderPass } from 'postprocessing'
+import { PerspectiveCamera, Scene, WebGLRenderer } from 'three'
 
 export class EngineScene {
   public scene: Scene
   public camera: PerspectiveCamera
+  public passes: Pass[]
+  public renderer: WebGLRenderer
 
   constructor() {
     this.scene = new Scene()
     this.camera = new PerspectiveCamera(75, undefined, 0.1, 100000)
     this.camera.position.z = 5
+    const renderPass = new RenderPass(this.scene, this.camera)
+    this.passes = [renderPass]
   }
 
   setRatio(ratio: number): void {
     this.camera.aspect = ratio
     this.camera.updateProjectionMatrix()
+  }
+
+  addPass(pass: Pass): void {
+    this.passes.push(pass)
+  }
+
+  clearPasses(): void {
+    this.passes = [this.passes[0]]
   }
 }

--- a/src/engine/world/Renderer.ts
+++ b/src/engine/world/Renderer.ts
@@ -75,7 +75,6 @@ export class Renderer {
     const perc = 100 / ratio
     const height = width / ratio
 
-   // this.renderer.setSize(width, height)
     this.composer.setSize(width, height)
 
     // Set ratios for each scene

--- a/src/engine/world/SketchManager.ts
+++ b/src/engine/world/SketchManager.ts
@@ -1,11 +1,16 @@
+import { Group } from 'three'
 import { SketchModule } from '../store/types'
 import { getDebugScene } from './debugScene'
+import { Pass } from 'postprocessing'
+import { EngineScene } from './EngineScene'
 
 type SketchInstance = {
   // eslint-disable-next-line -- TODO: Type this!
   update: any
   // eslint-disable-next-line
-  root: any
+  root?: Group
+
+  getPasses?: (engineScene: EngineScene) => Pass[]
 }
 
 export class SketchManager {
@@ -13,7 +18,9 @@ export class SketchManager {
 
   private createSketch = (instanceId: string, module: SketchModule): SketchInstance => {
     const sketch = new module()
-    sketch.root.name = instanceId
+    if (sketch.root) {
+      sketch.root.name = instanceId
+    }
 
     this.sketchInstances[instanceId] = sketch
 
@@ -23,8 +30,9 @@ export class SketchManager {
   public addSketchToScene = (instanceId: string, module: SketchModule): void => {
     const scene = getDebugScene().scene
     const sketch = this.createSketch(instanceId, module)
-
-    scene.add(sketch.root)
+    if (sketch.root) {
+      scene.add(sketch.root)
+    }
   }
 
   public removeSketchFromScene = (instanceId: string): void => {

--- a/src/engine/world/debugScene.ts
+++ b/src/engine/world/debugScene.ts
@@ -1,6 +1,7 @@
 // import { BoxGeometry, Mesh, MeshNormalMaterial } from 'three'
 import { addScene } from './scenes'
 import { EngineScene } from './EngineScene'
+import { Renderer } from './Renderer'
 import { uid } from 'uid'
 
 let debugScene: EngineScene | undefined
@@ -11,10 +12,11 @@ export const getDebugScene = (): EngineScene => {
   return debugScene
 }
 
-export const createDebugScene = (aspectRatio: number): EngineScene => {
+export const createDebugScene = (renderer: Renderer): EngineScene => {
   const id = uid()
   const scene = addScene(id)
-  scene.setRatio(aspectRatio)
+  scene.setRatio(renderer.aspectRatio)
+  scene.renderer = renderer.composer?.getRenderer()
 
   debugScene = scene
 


### PR DESCRIPTION
Adds basic post processing.

Post effects are queried from the sketches and placed in the EngineScene.

The Renderer now uses an EffectsCompositor

![image](https://github.com/user-attachments/assets/9c7619e3-5eb9-4ade-ab37-fa6ed8cfec4c)

I’ll add a demo sketch before this merges 