### PR TITLE
glsl support for sketches

### DIFF
--- a/example-project/sketches/hsl/hsl.glsl
+++ b/example-project/sketches/hsl/hsl.glsl
@@ -1,5 +1,3 @@
-export default `
-
 uniform sampler2D u_texture;
 uniform vec3 u_hsl;  // Hue, saturation, lightness adjustments
 varying vec2 vUv;
@@ -63,4 +61,3 @@ void main() {
 
     gl_FragColor = vec4(rgb, 1.0);
 }
-`;

--- a/example-project/sketches/hsl/index.ts
+++ b/example-project/sketches/hsl/index.ts
@@ -1,16 +1,16 @@
-import { EffectPass, SavePass, CopyPass, Pass, ShaderPass } from 'postprocessing'
-import { Uniform, Texture, Scene, Camera, WebGLRenderer, WebGLRenderTarget, ShaderMaterial, Vector3 } from 'three';
+import { Pass, ShaderPass } from 'postprocessing'
+import { Uniform, Texture, ShaderMaterial, Vector3 } from 'three'
 
-import fragmentShader from './hsl.js';
+import fragmentShader from './hsl.glsl'
 
 /**
  * A basic post proicessing effect to adjust the hue, saturation, and lightness of the scene.
  * While this could be created with existing postprocessing passes, this example demonstrates how to create a custom effect.
  */
 export default class HSL {
-  shader: ShaderMaterial;
-  pass: ShaderPass;
-  passes:Pass[]
+  shader: ShaderMaterial
+  pass: ShaderPass
+  passes: Pass[]
 
   /**
    * Gets the passes for this effect.
@@ -20,35 +20,33 @@ export default class HSL {
    * You can also modify the pass list at any time, and Hedron will update the scene accordingly.
    */
   getPasses(): Pass[] {
-    if(!this.passes){
+    if (!this.passes) {
       this.createPasses()
     }
     return this.passes
   }
 
-  createPasses(){
+  createPasses() {
     this.shader = this.createBloom()
     this.pass = new ShaderPass(this.shader, 'u_texture')
-    this.passes = [
-      this.pass
-    ]
+    this.passes = [this.pass]
   }
 
   createBloom(): ShaderMaterial {
     const uniforms = [
       ['u_hsl', new Uniform(new Vector3(0.0, 1.0, 1.0))],
       ['u_texture', new Uniform(Texture)],
-    ];
+    ]
 
     return new ShaderMaterial({
-        uniforms: Object.fromEntries(uniforms),
-        vertexShader: `
+      uniforms: Object.fromEntries(uniforms),
+      vertexShader: `
 		varying vec2 vUv;
 		void main() {
 		    vUv = uv;
 		    gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 	    }`,
-        fragmentShader,
+      fragmentShader,
     })
   }
 
@@ -61,7 +59,7 @@ export default class HSL {
 
   setUniform(key: string, value: any) {
     if (this.shader.uniforms[key]) {
-      this.shader.uniforms[key].value = value;
+      this.shader.uniforms[key].value = value
     }
   }
 
@@ -71,32 +69,32 @@ export default class HSL {
    */
   getConfig() {
     return {
-        title: 'HSL',
-        description: 'Hue, Saturation, Lightness',
-        category: 'simple',
-        params: [
-            {
-                title: 'Hue',
-                key: 'hue',
-                defaultValue: 0.0,
-                defaultMin: 0.0,
-                defaultMax: 1.0,
-            },
-            {
-                title: 'Saturation',
-                key: 'saturation',
-                defaultValue: 1.0,
-                defaultMin: 0.0,
-                defaultMax: 1.0,
-            },
-            {
-                title: 'Lightness',
-                key: 'lightness',
-                defaultValue: 1.0,
-                defaultMin: 0.0,
-                defaultMax: 1.0,
-            },
-        ],
+      title: 'HSL',
+      description: 'Hue, Saturation, Lightness',
+      category: 'simple',
+      params: [
+        {
+          title: 'Hue',
+          key: 'hue',
+          defaultValue: 0.0,
+          defaultMin: 0.0,
+          defaultMax: 1.0,
+        },
+        {
+          title: 'Saturation',
+          key: 'saturation',
+          defaultValue: 1.0,
+          defaultMin: 0.0,
+          defaultMax: 1.0,
+        },
+        {
+          title: 'Lightness',
+          key: 'lightness',
+          defaultValue: 1.0,
+          defaultMin: 0.0,
+          defaultMax: 1.0,
+        },
+      ],
     }
   }
 }

--- a/example-project/types.d.ts
+++ b/example-project/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.glsl' {
+  const content: string
+  export default content
+}

--- a/src/main/SketchesServer.ts
+++ b/src/main/SketchesServer.ts
@@ -13,26 +13,6 @@ const HOST = process.platform.startsWith('win') ? 'localhost' : '0.0.0.0'
 
 const WATCH_DEBOUNCE_MS = 300
 
-const fileExtensions = [
-  'glb',
-  'fbx',
-  'obj',
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'svg',
-  'mp3',
-  'mp4',
-  'ogg',
-  'wav',
-]
-
-const loaderFileExtensions: { [key: string]: 'file' } = {}
-fileExtensions.forEach((ext) => {
-  loaderFileExtensions[`.${ext}`] = 'file'
-})
-
 const getSketchIdFromPath = (sketchPath: string): string => {
   const folderName = path.dirname(sketchPath).split(path.sep).pop()
   if (!folderName) return sketchPath
@@ -87,7 +67,25 @@ export class SketchesServer extends EventEmitter {
         `${entryBase}/**/config.ts`,
       ],
       outdir,
-      loader: loaderFileExtensions,
+      loader: {
+        // https://esbuild.github.io/content-types/
+        // file: loaded into sketch as path
+        '.glb': 'file',
+        '.fbx': 'file',
+        '.obj': 'file',
+        '.png': 'file',
+        '.jpg': 'file',
+        '.jpeg': 'file',
+        '.gif': 'file',
+        '.svg': 'file',
+        '.mp3': 'file',
+        '.mp4': 'file',
+        '.ogg': 'file',
+        '.wav': 'file',
+        // text: loaded into sketch as string
+        '.glsl': 'text',
+        '.isf': 'text',
+      },
       assetNames: '[dir]/[name]-[hash]',
       publicPath: `http://${HOST}:${port}`,
       bundle: true,


### PR DESCRIPTION
Adds glsl support for sketches. The main change is in `SketchesServer.ts`. Most of the changes you see in the sketch file are just because of linting. I also added a type declaration in the example project so TS knows we're importing a string here (eventually I'm hoping we can have these types automatically as an npm package)