### PR TITLE
Relative and absolute sketches path in project file

### DIFF
--- a/example-project/project.json
+++ b/example-project/project.json
@@ -1,8 +1,5 @@
 {
   "version": 0,
-  "app": {
-    "sketchesDir": "./sketches"
-  },
   "engine": {
     "sketches": {
       "c64ceed4673": {
@@ -35,6 +32,19 @@
           "72e7c5d3f4a45228",
           "2e7c5d3f4a45228b",
           "e7c5d3f4a45228b7"
+        ]
+      },
+      "1359768f6f5f09f4": {
+        "id": "1359768f6f5f09f4",
+        "moduleId": "solid",
+        "title": "Solid",
+        "paramIds": [
+          "359768f6f5f09f4d",
+          "59768f6f5f09f4db",
+          "9768f6f5f09f4dbf",
+          "768f6f5f09f4dbf5",
+          "68f6f5f09f4dbf57",
+          "8f6f5f09f4dbf57a"
         ]
       }
     },
@@ -150,6 +160,48 @@
         "type": "param",
         "valueType": "enum",
         "sketchId": "785d72e7c5d3f4a4"
+      },
+      "359768f6f5f09f4d": {
+        "id": "359768f6f5f09f4d",
+        "key": "rotSpeedX",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "1359768f6f5f09f4"
+      },
+      "59768f6f5f09f4db": {
+        "id": "59768f6f5f09f4db",
+        "key": "rotSpeedY",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "1359768f6f5f09f4"
+      },
+      "9768f6f5f09f4dbf": {
+        "id": "9768f6f5f09f4dbf",
+        "key": "rotSpeedZ",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "1359768f6f5f09f4"
+      },
+      "768f6f5f09f4dbf5": {
+        "id": "768f6f5f09f4dbf5",
+        "key": "scale",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "1359768f6f5f09f4"
+      },
+      "68f6f5f09f4dbf57": {
+        "id": "68f6f5f09f4dbf57",
+        "key": "isWireframe",
+        "type": "param",
+        "valueType": "boolean",
+        "sketchId": "1359768f6f5f09f4"
+      },
+      "8f6f5f09f4dbf57a": {
+        "id": "8f6f5f09f4dbf57a",
+        "key": "geomName",
+        "type": "param",
+        "valueType": "enum",
+        "sketchId": "1359768f6f5f09f4"
       }
     },
     "nodeValues": {
@@ -168,7 +220,14 @@
       "d72e7c5d3f4a4522": 0.5,
       "72e7c5d3f4a45228": 1,
       "2e7c5d3f4a45228b": true,
-      "e7c5d3f4a45228b7": "icosa"
+      "e7c5d3f4a45228b7": "icosa",
+      "359768f6f5f09f4d": 0,
+      "59768f6f5f09f4db": 0,
+      "9768f6f5f09f4dbf": 0,
+      "768f6f5f09f4dbf5": 1,
+      "68f6f5f09f4dbf57": true,
+      "8f6f5f09f4dbf57a": "cube"
     }
-  }
+  },
+  "app": { "sketchesDir": "./sketches" }
 }

--- a/example-project/project.json
+++ b/example-project/project.json
@@ -1,1 +1,174 @@
-{"sketches":{"c64ceed4673":{"id":"c64ceed4673","moduleId":"solid","title":"Solid","paramIds":["64ceed46737","4ceed467370","ceed467370c","eed467370c5","ed467370c5c","d467370c5cb"]},"5cbd2fda13a":{"id":"5cbd2fda13a","moduleId":"stars","title":"stars","paramIds":["cbd2fda13a6","bd2fda13a6c","d2fda13a6c0","2fda13a6c07"]},"785d72e7c5d3f4a4":{"id":"785d72e7c5d3f4a4","moduleId":"solid","title":"Solid","paramIds":["85d72e7c5d3f4a45","5d72e7c5d3f4a452","d72e7c5d3f4a4522","72e7c5d3f4a45228","2e7c5d3f4a45228b","e7c5d3f4a45228b7"]}},"nodes":{"64ceed46737":{"id":"64ceed46737","key":"rotSpeedX","type":"param","valueType":"number","sketchId":"c64ceed4673"},"4ceed467370":{"id":"4ceed467370","key":"rotSpeedY","type":"param","valueType":"number","sketchId":"c64ceed4673"},"ceed467370c":{"id":"ceed467370c","key":"rotSpeedZ","type":"param","valueType":"number","sketchId":"c64ceed4673"},"eed467370c5":{"id":"eed467370c5","key":"scale","type":"param","valueType":"number","sketchId":"c64ceed4673"},"ed467370c5c":{"id":"ed467370c5c","key":"isWireframe","type":"param","valueType":"boolean","sketchId":"c64ceed4673"},"d467370c5cb":{"id":"d467370c5cb","key":"geomName","type":"param","valueType":"enum","sketchId":"c64ceed4673"},"cbd2fda13a6":{"id":"cbd2fda13a6","key":"opacity","type":"param","valueType":"number","sketchId":"5cbd2fda13a"},"bd2fda13a6c":{"id":"bd2fda13a6c","key":"speed","type":"param","valueType":"number","sketchId":"5cbd2fda13a"},"d2fda13a6c0":{"id":"d2fda13a6c0","key":"velocity","type":"param","valueType":"number","sketchId":"5cbd2fda13a"},"2fda13a6c07":{"id":"2fda13a6c07","key":"randomWalk","type":"param","valueType":"number","sketchId":"5cbd2fda13a"},"85d72e7c5d3f4a45":{"id":"85d72e7c5d3f4a45","key":"rotSpeedX","type":"param","valueType":"number","sketchId":"785d72e7c5d3f4a4"},"5d72e7c5d3f4a452":{"id":"5d72e7c5d3f4a452","key":"rotSpeedY","type":"param","valueType":"number","sketchId":"785d72e7c5d3f4a4"},"d72e7c5d3f4a4522":{"id":"d72e7c5d3f4a4522","key":"rotSpeedZ","type":"param","valueType":"number","sketchId":"785d72e7c5d3f4a4"},"72e7c5d3f4a45228":{"id":"72e7c5d3f4a45228","key":"scale","type":"param","valueType":"number","sketchId":"785d72e7c5d3f4a4"},"2e7c5d3f4a45228b":{"id":"2e7c5d3f4a45228b","key":"isWireframe","type":"param","valueType":"boolean","sketchId":"785d72e7c5d3f4a4"},"e7c5d3f4a45228b7":{"id":"e7c5d3f4a45228b7","key":"geomName","type":"param","valueType":"enum","sketchId":"785d72e7c5d3f4a4"}},"nodeValues":{"64ceed46737":0.5,"4ceed467370":0.5,"ceed467370c":0.5,"eed467370c5":0.5,"ed467370c5c":false,"d467370c5cb":"octa","cbd2fda13a6":1,"bd2fda13a6c":1,"d2fda13a6c0":0,"2fda13a6c07":0,"85d72e7c5d3f4a45":0.5,"5d72e7c5d3f4a452":0.5,"d72e7c5d3f4a4522":0.5,"72e7c5d3f4a45228":1,"2e7c5d3f4a45228b":true,"e7c5d3f4a45228b7":"icosa"}}
+{
+  "version": 0,
+  "app": {
+    "sketchesDir": "./sketches"
+  },
+  "engine": {
+    "sketches": {
+      "c64ceed4673": {
+        "id": "c64ceed4673",
+        "moduleId": "solid",
+        "title": "Solid",
+        "paramIds": [
+          "64ceed46737",
+          "4ceed467370",
+          "ceed467370c",
+          "eed467370c5",
+          "ed467370c5c",
+          "d467370c5cb"
+        ]
+      },
+      "5cbd2fda13a": {
+        "id": "5cbd2fda13a",
+        "moduleId": "stars",
+        "title": "stars",
+        "paramIds": ["cbd2fda13a6", "bd2fda13a6c", "d2fda13a6c0", "2fda13a6c07"]
+      },
+      "785d72e7c5d3f4a4": {
+        "id": "785d72e7c5d3f4a4",
+        "moduleId": "solid",
+        "title": "Solid",
+        "paramIds": [
+          "85d72e7c5d3f4a45",
+          "5d72e7c5d3f4a452",
+          "d72e7c5d3f4a4522",
+          "72e7c5d3f4a45228",
+          "2e7c5d3f4a45228b",
+          "e7c5d3f4a45228b7"
+        ]
+      }
+    },
+    "nodes": {
+      "64ceed46737": {
+        "id": "64ceed46737",
+        "key": "rotSpeedX",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "c64ceed4673"
+      },
+      "4ceed467370": {
+        "id": "4ceed467370",
+        "key": "rotSpeedY",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "c64ceed4673"
+      },
+      "ceed467370c": {
+        "id": "ceed467370c",
+        "key": "rotSpeedZ",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "c64ceed4673"
+      },
+      "eed467370c5": {
+        "id": "eed467370c5",
+        "key": "scale",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "c64ceed4673"
+      },
+      "ed467370c5c": {
+        "id": "ed467370c5c",
+        "key": "isWireframe",
+        "type": "param",
+        "valueType": "boolean",
+        "sketchId": "c64ceed4673"
+      },
+      "d467370c5cb": {
+        "id": "d467370c5cb",
+        "key": "geomName",
+        "type": "param",
+        "valueType": "enum",
+        "sketchId": "c64ceed4673"
+      },
+      "cbd2fda13a6": {
+        "id": "cbd2fda13a6",
+        "key": "opacity",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "5cbd2fda13a"
+      },
+      "bd2fda13a6c": {
+        "id": "bd2fda13a6c",
+        "key": "speed",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "5cbd2fda13a"
+      },
+      "d2fda13a6c0": {
+        "id": "d2fda13a6c0",
+        "key": "velocity",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "5cbd2fda13a"
+      },
+      "2fda13a6c07": {
+        "id": "2fda13a6c07",
+        "key": "randomWalk",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "5cbd2fda13a"
+      },
+      "85d72e7c5d3f4a45": {
+        "id": "85d72e7c5d3f4a45",
+        "key": "rotSpeedX",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "785d72e7c5d3f4a4"
+      },
+      "5d72e7c5d3f4a452": {
+        "id": "5d72e7c5d3f4a452",
+        "key": "rotSpeedY",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "785d72e7c5d3f4a4"
+      },
+      "d72e7c5d3f4a4522": {
+        "id": "d72e7c5d3f4a4522",
+        "key": "rotSpeedZ",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "785d72e7c5d3f4a4"
+      },
+      "72e7c5d3f4a45228": {
+        "id": "72e7c5d3f4a45228",
+        "key": "scale",
+        "type": "param",
+        "valueType": "number",
+        "sketchId": "785d72e7c5d3f4a4"
+      },
+      "2e7c5d3f4a45228b": {
+        "id": "2e7c5d3f4a45228b",
+        "key": "isWireframe",
+        "type": "param",
+        "valueType": "boolean",
+        "sketchId": "785d72e7c5d3f4a4"
+      },
+      "e7c5d3f4a45228b7": {
+        "id": "e7c5d3f4a45228b7",
+        "key": "geomName",
+        "type": "param",
+        "valueType": "enum",
+        "sketchId": "785d72e7c5d3f4a4"
+      }
+    },
+    "nodeValues": {
+      "64ceed46737": 0.5,
+      "4ceed467370": 0.5,
+      "ceed467370c": 0.5,
+      "eed467370c5": 0.5,
+      "ed467370c5c": false,
+      "d467370c5cb": "octa",
+      "cbd2fda13a6": 1,
+      "bd2fda13a6c": 1,
+      "d2fda13a6c0": 0,
+      "2fda13a6c07": 0,
+      "85d72e7c5d3f4a45": 0.5,
+      "5d72e7c5d3f4a452": 0.5,
+      "d72e7c5d3f4a4522": 0.5,
+      "72e7c5d3f4a45228": 1,
+      "2e7c5d3f4a45228b": true,
+      "e7c5d3f4a45228b7": "icosa"
+    }
+  }
+}

--- a/example-project/project.json
+++ b/example-project/project.json
@@ -229,5 +229,5 @@
       "8f6f5f09f4dbf57a": "cube"
     }
   },
-  "app": { "sketchesDir": "./sketches" }
+  "app": { "sketchesDir": "sketches" }
 }

--- a/src/engine/HedronEngine.ts
+++ b/src/engine/HedronEngine.ts
@@ -5,7 +5,7 @@ import { createDebugScene } from './world/debugScene'
 import { Renderer } from './world/Renderer'
 import { SketchManager } from './world/SketchManager'
 import { importSketchModule } from './importSketchModule'
-import { ProjectData } from './store/types'
+import { EngineData } from './store/types'
 import { stripForSave } from './utils/stripForSave'
 
 export class HedronEngine {
@@ -83,7 +83,7 @@ export class HedronEngine {
     return this.store
   }
 
-  public getSaveData(): ProjectData {
+  public getSaveData(): EngineData {
     return stripForSave(this.store.getState())
   }
 

--- a/src/engine/store/actionCreators/loadProject.ts
+++ b/src/engine/store/actionCreators/loadProject.ts
@@ -1,5 +1,5 @@
-import { ProjectData, SetterCreator } from '../types'
+import { EngineData, SetterCreator } from '../types'
 
 export const createLoadProject: SetterCreator<'loadProject'> =
-  (setState) => (project: ProjectData) =>
+  (setState) => (project: EngineData) =>
     setState(() => project)

--- a/src/engine/store/types.ts
+++ b/src/engine/store/types.ts
@@ -94,7 +94,7 @@ export type DialogId = 'sketchModules'
 
 export type EnumOption = { value: string; label: string }
 
-export interface ProjectData {
+export interface EngineData {
   sketches: Sketches
   nodes: Nodes
   nodeValues: NodeValues
@@ -105,7 +105,7 @@ interface AuxState {
   isSketchModulesReady: boolean
 }
 
-export type EngineState = ProjectData & AuxState
+export type EngineState = EngineData & AuxState
 
 interface Actions {
   addSketch: (moduleId: string) => string
@@ -114,11 +114,11 @@ interface Actions {
   setSketchModuleItem: (newItem: SketchModuleItem) => void
   updateNodeValue: (nodeId: string, value: NodeValue) => void
   deleteSketchModule: (moduleId: string) => void
-  loadProject: (project: ProjectData) => void
+  loadProject: (project: EngineData) => void
   reset: () => void
 }
 
-export type EngineStateWithActions = ProjectData & AuxState & Actions
+export type EngineStateWithActions = EngineData & AuxState & Actions
 
 export type SetState = StoreApi<EngineStateWithActions>['setState']
 

--- a/src/engine/utils/stripForSave.ts
+++ b/src/engine/utils/stripForSave.ts
@@ -1,6 +1,6 @@
-import { EngineState, EngineStateWithActions, ProjectData } from '../store/types'
+import { EngineState, EngineStateWithActions, EngineData } from '../store/types'
 
-export const stripForSave = (state: EngineStateWithActions): ProjectData => {
+export const stripForSave = (state: EngineStateWithActions): EngineData => {
   // @ts-expect-error ---
   const withoutActions: EngineState = {}
 

--- a/src/main/handlers/openProjectFile.ts
+++ b/src/main/handlers/openProjectFile.ts
@@ -23,9 +23,8 @@ export const openProjectFile = async (): Promise<OpenProjectResponse> => {
     // Get the directory of the project file
     const projectDir = path.dirname(projectFile)
 
-    // Find sketches dir from project data
-    const sketchesDir = projectData.app.sketchesDir
-    const sketchesDirAbsolute = path.resolve(projectDir, sketchesDir)
+    // Find sketches dir from project data (will work with rel or abs path)
+    const sketchesDirAbsolute = path.resolve(projectDir, projectData.app.sketchesDir)
 
     try {
       const stats = fs.statSync(sketchesDirAbsolute)

--- a/src/main/handlers/openProjectFile.ts
+++ b/src/main/handlers/openProjectFile.ts
@@ -2,6 +2,7 @@ import { dialog } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { OpenProjectResponse } from '../../shared/Events'
+import { ProjectData } from '../../shared/types'
 
 export const openProjectFile = async (): Promise<OpenProjectResponse> => {
   const result = await dialog.showOpenDialog({
@@ -17,16 +18,17 @@ export const openProjectFile = async (): Promise<OpenProjectResponse> => {
 
     // Read and parse the JSON from the project file
     const fileContent = fs.readFileSync(projectFile, { encoding: 'utf8' })
-    const projectData = JSON.parse(fileContent)
+    const projectData = JSON.parse(fileContent) as ProjectData
 
     // Get the directory of the project file
     const projectDir = path.dirname(projectFile)
 
-    // Path to the neighboring 'sketches' directory
-    const sketchesDir = path.join(projectDir, 'sketches')
+    // Find sketches dir from project data
+    const sketchesDir = projectData.app.sketchesDir
+    const sketchesDirAbsolute = path.resolve(projectDir, sketchesDir)
 
     try {
-      const stats = fs.statSync(sketchesDir)
+      const stats = fs.statSync(sketchesDirAbsolute)
       if (!stats.isDirectory()) {
         return {
           result: 'error',
@@ -42,7 +44,7 @@ export const openProjectFile = async (): Promise<OpenProjectResponse> => {
     return {
       result: 'success',
       projectData,
-      sketchesDirPath: sketchesDir,
+      sketchesDirAbsolute,
       savePath: projectFile,
     }
   } catch (err) {

--- a/src/main/handlers/saveProjectFile.ts
+++ b/src/main/handlers/saveProjectFile.ts
@@ -1,9 +1,35 @@
 import { dialog } from 'electron'
 import fs from 'fs'
 import { SaveProjectResponse } from '../../shared/Events'
+import { ProjectData } from '../../shared/types'
+import path from 'path'
+
+const isSubdirectory = (parentDir: string, directory: string) => {
+  const resolvedParentDir = path.resolve(parentDir)
+  const resolvedDirectory = path.resolve(directory)
+
+  // Check if the directory starts with the parent directory path
+  return resolvedDirectory.startsWith(resolvedParentDir + path.sep)
+}
+
+const convertPathToRelative = (projectFilePath: string, sketchesDirPath: string) => {
+  // skip if sketches dir is already relative
+  if (!path.isAbsolute(sketchesDirPath)) return sketchesDirPath
+
+  const parentDir = path.dirname(projectFilePath)
+
+  // Check if the target directory is inside the parent directory
+  if (isSubdirectory(parentDir, sketchesDirPath)) {
+    // Get the relative path from the parent directory to the target directory
+    return path.relative(parentDir, sketchesDirPath)
+  }
+
+  // Return absolute if it's not a relative
+  return sketchesDirPath
+}
 
 export const saveProjectFile = async (
-  projectData: string,
+  projectData: ProjectData,
   _savePath: string | null,
 ): Promise<SaveProjectResponse> => {
   let savePath = _savePath
@@ -21,6 +47,8 @@ export const saveProjectFile = async (
 
     savePath = result.filePath
   }
+
+  projectData.app.sketchesDir = convertPathToRelative(savePath, projectData.app.sketchesDir)
 
   try {
     const fileContent = JSON.stringify(projectData)

--- a/src/renderer/handlers/fileHandlers.ts
+++ b/src/renderer/handlers/fileHandlers.ts
@@ -42,6 +42,7 @@ export const handleLoadProjectDialog = async () => {
 
   engineStore.getState().loadProject(projectData.engine)
   useAppStore.getState().setCurrentSavePath(savePath)
+  useAppStore.getState().setSketchesDir(sketchesDirAbsolute)
 }
 
 export const handleSaveProjectDialog = async (options?: { saveAs?: boolean }) => {

--- a/src/renderer/handlers/fileHandlers.ts
+++ b/src/renderer/handlers/fileHandlers.ts
@@ -35,11 +35,11 @@ export const handleLoadProjectDialog = async () => {
     return
   }
 
-  const { sketchesDirPath, projectData, savePath } = response
+  const { sketchesDirAbsolute, projectData, savePath } = response
 
-  await startEngineWithSketchesDir(sketchesDirPath)
+  await startEngineWithSketchesDir(sketchesDirAbsolute)
 
-  engineStore.getState().loadProject(projectData)
+  engineStore.getState().loadProject(projectData.engine)
   useAppStore.getState().setCurrentSavePath(savePath)
 }
 

--- a/src/renderer/handlers/fileHandlers.ts
+++ b/src/renderer/handlers/fileHandlers.ts
@@ -1,3 +1,4 @@
+import { ProjectData } from 'src/shared/types'
 import { useAppStore } from '../appStore'
 import { engine, engineStore } from '../engine'
 import {
@@ -8,7 +9,6 @@ import {
 } from '../ipc/mainThreadTalk'
 
 const startEngineWithSketchesDir = async (sketchesDirPath: string) => {
-  useAppStore.getState().setSketchesDir(sketchesDirPath)
   const { moduleIds, url } = await startSketchesServer(sketchesDirPath)
 
   engine.setSketchesUrl(url)
@@ -18,11 +18,12 @@ const startEngineWithSketchesDir = async (sketchesDirPath: string) => {
 }
 
 export const handleSketchesDialog = async () => {
-  const sketchesDirPath = await openSketchesDirDialog()
+  const sketchesDir = await openSketchesDirDialog()
 
-  if (!sketchesDirPath) return
+  if (!sketchesDir) return
 
-  await startEngineWithSketchesDir(sketchesDirPath)
+  useAppStore.getState().setSketchesDir(sketchesDir)
+  await startEngineWithSketchesDir(sketchesDir)
 }
 
 export const handleLoadProjectDialog = async () => {
@@ -44,11 +45,24 @@ export const handleLoadProjectDialog = async () => {
 }
 
 export const handleSaveProjectDialog = async (options?: { saveAs?: boolean }) => {
-  const data = engine.getSaveData()
+  const sketchesDir = useAppStore.getState().sketchesDir
+
+  if (!sketchesDir) {
+    throw new Error("Can't save project without sketches dir")
+  }
+
+  const engineData = engine.getSaveData()
+  const projectData: ProjectData = {
+    version: 0,
+    engine: engineData,
+    app: {
+      sketchesDir,
+    },
+  }
 
   const savePath = options?.saveAs ? null : useAppStore.getState().currentSavePath
 
-  const response = await saveProjectFileDialog(data, { savePath })
+  const response = await saveProjectFileDialog(projectData, { savePath })
 
   if (response.result === 'error') {
     alert(response.error)

--- a/src/renderer/ipc/mainThreadTalk.ts
+++ b/src/renderer/ipc/mainThreadTalk.ts
@@ -1,4 +1,4 @@
-import { ProjectData } from 'src/engine/store/types'
+import { EngineData } from 'src/engine/store/types'
 import {
   DialogEvents,
   FileEvents,
@@ -7,6 +7,7 @@ import {
   SketchesServerResponse,
   SketchEvents,
 } from 'src/shared/Events'
+import { ProjectData } from '../../shared/types'
 
 export const openSketchesDirDialog = () =>
   new Promise<string | undefined>((resolve) => {

--- a/src/shared/Events.ts
+++ b/src/shared/Events.ts
@@ -1,3 +1,5 @@
+import { ProjectData } from './types'
+
 export enum SketchEvents {
   StartSketchesServer = 'start-sketches-server',
   NewSketch = 'new-sketch',
@@ -47,9 +49,9 @@ type ResponseError = {
 
 type OpenProjectResponseSuccess = {
   result: 'success'
-  sketchesDirPath: string
+  sketchesDirAbsolute: string
   savePath: string
-  projectData: any
+  projectData: ProjectData
 }
 
 type SaveProjectResponseSuccess = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,9 @@
+import { EngineData } from 'src/engine/store/types'
+
+export interface ProjectData {
+  version: number
+  engine: EngineData
+  app: {
+    sketchesDir: string
+  }
+}


### PR DESCRIPTION
- sketches dir is now saved in the project
- project json is now split into `engine` and `app` data
- sketches dir in project can either be an absolute path or a path relative to the parent of the JSON file.
- When the sketches dir is some ancestor of this parent, it is automatically saved as a relative path. This means we can happily send project folders around without having to relocate the sketches dir.
- If the sketches folder doesn't share the same ancestry, we just keep it as an absolute path