### PR TITLE
potential gh actions fix

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,21 +19,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Yarn
-        run: corepack enable && corepack prepare yarn@4.5.3 --activate # Specify the Yarn version you're using
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            .yarn/cache
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Install dependencies
-        run: yarn install --immutable --check-cache # Immutable mode to ensure lock file consistency
+        run: yarn install --mode=skip-build
 
       - name: Run TypeScript, ESLint, and Prettier checks
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,8 +19,21 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install Yarn
+        run: corepack enable && corepack prepare yarn@4.5.3 --activate # Specify the Yarn version you're using
+
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            .yarn/cache
+            node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install dependencies
-        run: yarn
+        run: yarn install --immutable --check-cache # Immutable mode to ensure lock file consistency
 
       - name: Run TypeScript, ESLint, and Prettier checks
         run: |


### PR DESCRIPTION
Github actions was failing. This was due to the new version of `yarn` trying to run `postinstall` on `@hedron/desktop`. This would be a huge operation (e.g. downloading binaries, etc) and would timeout. Using `yarn install --mode=skip-build` to get around this. We don't need electron stuff for simple checks like TS and linting!