### PR TITLE
bad sketches dont block run

### DIFF
--- a/packages/engine/src/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine.ts
@@ -36,7 +36,11 @@ export class HedronEngine {
 
   public async initiateSketchModules(moduleIds: string[]) {
     for (const moduleId of moduleIds) {
-      await this.addSketchModule(moduleId)
+      try {
+        await this.addSketchModule(moduleId)
+      } catch (error) {
+        console.error('Init error in: ' + moduleId, error)
+      }
     }
 
     this.store.setState({ isSketchModulesReady: true })

--- a/packages/engine/src/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine.ts
@@ -49,7 +49,7 @@ export class HedronEngine {
     const result = await importSketchModule(this.sketchesUrl, moduleId)
 
     if (!result.success) {
-      // TODO: check for errors and show UI error
+      // TODO: Show UI error here (engine needs to have some "error" state slice)
       return result
     }
 

--- a/packages/engine/src/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine.ts
@@ -1,10 +1,11 @@
 import { listenToStore } from './storeListener'
 import { importSketchModule } from './importSketchModule'
+import { Result } from './types'
 import { stripForSave } from '@utils/stripForSave'
 import { Renderer } from '@world/Renderer'
 import { SketchManager } from '@world/SketchManager'
 import { createDebugScene } from '@world/debugScene'
-import { EngineData } from '@store/types'
+import { EngineData, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
 import { createEngineStore, EngineStore } from '@store/engineStore'
 
@@ -36,31 +37,40 @@ export class HedronEngine {
 
   public async initiateSketchModules(moduleIds: string[]) {
     for (const moduleId of moduleIds) {
-      try {
-        await this.addSketchModule(moduleId)
-      } catch (error) {
-        console.error('Init error in: ' + moduleId, error)
-      }
+      await this.addSketchModule(moduleId)
     }
 
     this.store.setState({ isSketchModulesReady: true })
   }
 
-  public async addSketchModule(moduleId: string) {
+  public async addSketchModule(moduleId: string): Promise<Result<SketchModuleItem>> {
     if (!this.sketchesUrl) throw new Error('Sketches URL not ready')
 
-    const moduleItem = await importSketchModule(this.sketchesUrl, moduleId)
+    const result = await importSketchModule(this.sketchesUrl, moduleId)
+
+    if (!result.success) {
+      // TODO: check for errors and show UI error
+      return result
+    }
+
+    const moduleItem = result.data
     this.store.getState().setSketchModuleItem(moduleItem)
 
-    return moduleItem
+    return result
   }
 
   public removeSketchModule = async (moduleId: string): Promise<void> => {
     this.store.getState().deleteSketchModule(moduleId)
   }
 
-  public async reimportSketchModuleAndReloadSketches(moduleId: string) {
-    const moduleItem = await this.addSketchModule(moduleId)
+  public async reimportSketchModuleAndReloadSketches(moduleId: string): Promise<void> {
+    const result = await this.addSketchModule(moduleId)
+
+    if (!result.success) {
+      return
+    }
+
+    const moduleItem = result.data
 
     const sketchesToRefresh = getSketchesOfModuleId(this.store.getState(), moduleId)
 

--- a/packages/engine/src/importSketchModule.ts
+++ b/packages/engine/src/importSketchModule.ts
@@ -1,46 +1,61 @@
+import { Result } from './types'
 import { SketchConfig, SketchModule, SketchModuleItem } from '@store/types'
 import { createUniqueId } from '@utils/createUniqueId'
 
 export const importSketchModule = async (
   baseUrl: string,
   moduleId: string,
-): Promise<SketchModuleItem> => {
-  const cacheBust = createUniqueId()
+): Promise<Result<SketchModuleItem>> => {
+  try {
+    const cacheBust = createUniqueId()
 
-  // Get the sketch module
-  const sketchPath = `${baseUrl}/${moduleId}/index.js?${cacheBust}`
-  if ((await fetch(sketchPath)).status !== 200) {
-    return Promise.reject(`Sketch module not found: ${sketchPath}`)
-  }
-  const sketchModule = await import(/* @vite-ignore */ sketchPath)
-  const module: SketchModule = sketchModule.default
-
-  // Get the sketch config
-  const configPath = `${baseUrl}/${moduleId}/config.js?${cacheBust}`
-  let config: SketchConfig
-  if ((await fetch(configPath)).status !== 200) {
-    // No config file found
-    // Try instancing the sketch, and call getConfig() on it
-    const tempModule = new module()
-    config = tempModule.getConfig?.()
-    if (!config) {
-      return Promise.reject(
-        `Sketch config not found: ${configPath} and no valid getConfig() function found in sketch`,
-      )
+    // Get the sketch module
+    const sketchPath = `${baseUrl}/${moduleId}/index.js?${cacheBust}`
+    if ((await fetch(sketchPath)).status !== 200) {
+      return Promise.reject(`Sketch module not found: ${sketchPath}`)
     }
-  } else {
-    const configModule = await import(/* @vite-ignore */ configPath)
-    config = configModule.default
-  }
+    const sketchModule = await import(/* @vite-ignore */ sketchPath)
+    const module: SketchModule = sketchModule.default
 
-  // A config could be missing a title, but it is a required parameter
-  if (!config.title) {
-    config.title = moduleId
-  }
+    // Get the sketch config
+    const configPath = `${baseUrl}/${moduleId}/config.js?${cacheBust}`
+    let config: SketchConfig
+    if ((await fetch(configPath)).status !== 200) {
+      // No config file found
+      // Try instancing the sketch, and call getConfig() on it
+      const tempModule = new module()
+      config = tempModule.getConfig?.()
+      if (!config) {
+        return Promise.reject(
+          `Sketch config not found: ${configPath} and no valid getConfig() function found in sketch`,
+        )
+      }
+    } else {
+      const configModule = await import(/* @vite-ignore */ configPath)
+      config = configModule.default
+    }
 
-  return {
-    moduleId,
-    config,
-    module,
+    // A config could be missing a title, but it is a required parameter
+    if (!config.title) {
+      config.title = moduleId
+    }
+
+    return {
+      success: true,
+      error: undefined,
+      data: {
+        moduleId,
+        config,
+        module,
+      },
+    }
+  } catch (error) {
+    console.error(error)
+
+    return {
+      data: undefined,
+      success: false,
+      error: `[HEDRON] Sketch module failed to import: ${moduleId}`,
+    }
   }
 }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,0 +1,3 @@
+export type Result<T> =
+  | { success: true; data: T; error: undefined }
+  | { success: false; error: string; data: undefined }


### PR DESCRIPTION
I had a sketch that was now failing due to the removal of `THREE.GLTFLoader`, that said, there could be any number of things that break a sketch.

This change continues with the initialization so you can at least load sketches that did init properly.

The sketch that failed does not appear in the list of sketches you can add.

This might leave an issue when opening a project that wants to use an uninitialized sketch due to bad changes, but I doubt it would break any worse than failing to init the three scene