### PR TITLE
Post effect sketches without root properly reload

### DIFF
--- a/packages/engine/src/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine.ts
@@ -36,7 +36,11 @@ export class HedronEngine {
 
   public async initiateSketchModules(moduleIds: string[]) {
     for (const moduleId of moduleIds) {
-      await this.addSketchModule(moduleId)
+      try {
+        await this.addSketchModule(moduleId)
+      } catch (error) {
+        console.error('Init error in: ' + moduleId, error)
+      }
     }
 
     this.store.setState({ isSketchModulesReady: true })

--- a/packages/engine/src/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine.ts
@@ -112,6 +112,7 @@ export class HedronEngine {
 
         if (instance.getPasses) {
           instance.getPasses(debugScene).forEach((pass) => {
+            pass.name = sketch.id
             debugScene.addPass(pass)
           })
         }

--- a/packages/engine/src/world/EngineScene.ts
+++ b/packages/engine/src/world/EngineScene.ts
@@ -25,7 +25,15 @@ export class EngineScene {
     this.passes.push(pass)
   }
 
+  removePass(pass: Pass): void {
+    this.passes = this.passes.filter((p) => p !== pass)
+  }
+
   clearPasses(): void {
     this.passes = [this.renderPass]
+  }
+
+  getPassesByName(name: string): Pass[] {
+    return this.passes.filter((pass) => pass.name === name)
   }
 }

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -42,7 +42,7 @@ export class SketchManager {
     if (!oldSketch) {
       const pass = engineScene.getPassesByName(instanceId)
       if (pass?.length) {
-        pass.forEach((p) => engineScene.removePass(p))
+        pass.forEach(engineScene.removePass)
         delete this.sketchInstances[instanceId]
         return
       }

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -35,14 +35,21 @@ export class SketchManager {
   }
 
   public removeSketchFromScene = (instanceId: string): void => {
-    const scene = getDebugScene().scene
-    const oldSketch = scene.getObjectByName(instanceId)
+    const engineScene = getDebugScene()
+    const threeScene = engineScene.scene
+    const oldSketch = threeScene.getObjectByName(instanceId)
 
     if (!oldSketch) {
+      const pass = engineScene.getPassesByName(instanceId)
+      if (pass?.length) {
+        pass.forEach((p) => engineScene.removePass(p))
+        delete this.sketchInstances[instanceId]
+        return
+      }
       throw new Error(`couldn't find sketch to remove: ${instanceId}`)
     }
 
-    scene.remove(oldSketch)
+    threeScene.remove(oldSketch)
     delete this.sketchInstances[instanceId]
   }
 


### PR DESCRIPTION
If a sketch does not have an object named root, it fires an error when a code change is detected, requiring the user to manually remove and read the sketch.

This change checks to see if the refreshing sketch is one of the current post effects, and breaks early if so

accidentally added this off https://github.com/nudibranchrecords/hedron/pull/471 so review that first 😬 