### PR TITLE
Bottom panel

### DIFF
--- a/packages/desktop/.storybook/main.ts
+++ b/packages/desktop/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -12,6 +13,13 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/react-vite',
     options: {},
+  },
+  viteFinal: async (config) => {
+    // @ts-expect-error
+    config.plugins = [...config.plugins, tsconfigPaths()]
+    return {
+      ...config,
+    }
   },
 }
 export default config

--- a/packages/desktop/.storybook/preview.ts
+++ b/packages/desktop/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react'
-import '../@renderer/css/base.css'
+import '../src/renderer/css/base.css'
 
 const preview: Preview = {
   parameters: {

--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.module.css
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.module.css
@@ -1,3 +1,10 @@
 .section {
   margin-bottom: var(--gapXLarge);
 }
+
+.bottomPanel {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -5,7 +5,7 @@ import { useActiveSketch } from '@components/hooks/useActiveSketch'
 import { Button } from '@components/core/Button/Button'
 import { ViewHeader } from '@components/core/ViewHeader/ViewHeader'
 import { Card, CardActions } from '@components/core/Card/Card'
-import { Icon } from '@components/core/Icon/Icon'
+import { Icon, paramIcon } from '@components/core/Icon/Icon'
 import { Panel, PanelBody, PanelHeader } from '@components/core/Panel/Panel'
 import { useSelectedParam } from '@components/hooks/useSelectedParam'
 
@@ -38,8 +38,8 @@ export const ActiveSketch = () => {
         </CardActions>
       </Card>
       {selectedParam && (
-        <Panel snugPosition="bottom" spacing="slim" width="full">
-          <PanelHeader iconName="info">{selectedParam.title}</PanelHeader>
+        <Panel snugPosition="bottom" spacing="slim" width="full" className={c.bottomPanel}>
+          <PanelHeader iconName={paramIcon}>{selectedParam.title}</PanelHeader>
           <PanelBody>:)</PanelBody>
         </Panel>
       )}

--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -6,6 +6,8 @@ import { Button } from '@components/core/Button/Button'
 import { ViewHeader } from '@components/core/ViewHeader/ViewHeader'
 import { Card, CardActions } from '@components/core/Card/Card'
 import { Icon } from '@components/core/Icon/Icon'
+import { Panel, PanelBody, PanelHeader } from '@components/core/Panel/Panel'
+import { useSelectedParam } from '@components/hooks/useSelectedParam'
 
 export const ActiveSketch = () => {
   const activeSketch = useActiveSketch()
@@ -13,6 +15,8 @@ export const ActiveSketch = () => {
   if (!activeSketch) {
     throw new Error('ActiveSketch component: No activesketch found')
   }
+
+  const selectedParam = useSelectedParam()
 
   return (
     <>
@@ -33,6 +37,12 @@ export const ActiveSketch = () => {
           </Button>
         </CardActions>
       </Card>
+      {selectedParam && (
+        <Panel snugPosition="bottom" spacing="slim" width="full">
+          <PanelHeader iconName="info">{selectedParam.title}</PanelHeader>
+          <PanelBody>:)</PanelBody>
+        </Panel>
+      )}
     </>
   )
 }

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchModulesDialog.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchModulesDialog.tsx
@@ -63,7 +63,7 @@ export const SketchModulesDialog = ({ closeDialog }: GlobalDialogProps) => {
 
   return (
     <Dialog onBackgroundClick={closeDialog}>
-      <Panel size="full" style={{ maxWidth: '60rem' }}>
+      <Panel width="full" height="full" style={{ maxWidth: '60rem' }}>
         <PanelHeader iconName="add_circle" buttonOnClick={closeDialog}>
           Add sketch to scene
         </PanelHeader>

--- a/packages/desktop/src/renderer/components/SketchParams/SketchParams.tsx
+++ b/packages/desktop/src/renderer/components/SketchParams/SketchParams.tsx
@@ -1,6 +1,6 @@
-import { NodeTypes } from '@hedron/engine'
+import { NodeTypes, ParamWithInfo } from '@hedron/engine'
 import { useOnSelectNode } from '@components/hooks/useOnSelectNode'
-import { ParamWithInfo, useActiveSketchParams } from '@components/hooks/useActiveSketchParams'
+import { useActiveSketchParams } from '@components/hooks/useActiveSketchParams'
 import { ParamNumber } from '@components/ParamNumber/ParamNumber'
 import { ParamBoolean } from '@components/ParamBoolean/ParamBoolean'
 import { ParamEnum } from '@components/ParamEnum/ParamEnum'
@@ -36,7 +36,7 @@ const ParamItem = ({ param: { key, title, id, sketchId, valueType } }: ParamProp
   return (
     <NodeControl key={key} onClick={onSelectNode} isActive={id === selected}>
       <NodeControlMain>
-        <NodeControlTitle>{title ?? key}</NodeControlTitle>
+        <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>{getInputElement(valueType, id)}</NodeControlInner>
       </NodeControlMain>
     </NodeControl>

--- a/packages/desktop/src/renderer/components/Sketches/Sketches.module.css
+++ b/packages/desktop/src/renderer/components/Sketches/Sketches.module.css
@@ -6,6 +6,7 @@
 .main {
   flex: 1;
   padding: var(--gapLarge);
+  position: relative;
 }
 
 .nav {

--- a/packages/desktop/src/renderer/components/core/FloatSlider/FloatSlider.module.css
+++ b/packages/desktop/src/renderer/components/core/FloatSlider/FloatSlider.module.css
@@ -1,3 +1,11 @@
+:root {
+  --floatSliderBackgroundColor: var(--bgColorDark4);
+}
+
+:global(.themeLevel1) {
+  --floatSliderBackgroundColor: var(--bgColorDark3);
+}
+
 .wrapper {
   min-height: 1rem;
   height: 100%;
@@ -6,7 +14,7 @@
 }
 
 .canvas {
-  background: var(--bgColorDark4);
+  background: var(--floatSliderBackgroundColor);
   cursor: pointer;
   position: absolute;
   left: 0;

--- a/packages/desktop/src/renderer/components/core/Icon/Icon.tsx
+++ b/packages/desktop/src/renderer/components/core/Icon/Icon.tsx
@@ -18,9 +18,11 @@ export type IconName =
   | 'token'
   | 'close'
   | 'panorama'
+  | 'tune'
 
 export const sketchIcon: IconName = 'token'
 export const sceneIcon: IconName = 'panorama'
+export const paramIcon: IconName = 'tune'
 
 export interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
   name: IconName

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.module.css
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.module.css
@@ -14,6 +14,10 @@
   }
 }
 
+.colorLight {
+  background-color: var(--bgColorDark1);
+}
+
 .main {
   display: flex;
   align-items: center;

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.module.css
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.module.css
@@ -1,8 +1,16 @@
+:root {
+  --nodeControlBackgroundColor: var(--bgColorDark2);
+}
+
+:global(.themeLevel1) {
+  --nodeControlBackgroundColor: var(--bgColorDark1);
+}
+
 .wrapper {
   border-radius: 3px;
   color: var(--textColorLight1);
   fill: var(--textColorLight1);
-  background-color: var(--bgColorDark2);
+  background-color: var(--nodeControlBackgroundColor);
   padding: var(--gapSmall);
   display: flex;
   flex-direction: column;
@@ -12,10 +20,6 @@
   &:global(.active) {
     outline: 1px solid var(--lineColor2);
   }
-}
-
-.colorLight {
-  background-color: var(--bgColorDark1);
 }
 
 .main {

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
@@ -3,13 +3,17 @@ import c from './NodeControl.module.css'
 
 export interface NodeControlProps {
   isActive?: boolean
+  color?: 'light'
   children: React.ReactNode
   onClick?: () => void
 }
 
-export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) => {
+export const NodeControl = ({ isActive, children, color, onClick }: NodeControlProps) => {
   return (
-    <div onClick={onClick} className={`${c.wrapper} ${isActive && 'active'}`}>
+    <div
+      onClick={onClick}
+      className={`${c.wrapper} ${isActive && 'active'} ${color === 'light' && c.colorLight}`}
+    >
       {children}
     </div>
   )

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
@@ -3,17 +3,13 @@ import c from './NodeControl.module.css'
 
 export interface NodeControlProps {
   isActive?: boolean
-  color?: 'light'
   children: React.ReactNode
   onClick?: () => void
 }
 
-export const NodeControl = ({ isActive, children, color, onClick }: NodeControlProps) => {
+export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) => {
   return (
-    <div
-      onClick={onClick}
-      className={`${c.wrapper} ${isActive && 'active'} ${color === 'light' && c.colorLight}`}
-    >
+    <div onClick={onClick} className={`${c.wrapper} ${isActive && 'active'}`}>
       {children}
     </div>
   )

--- a/packages/desktop/src/renderer/components/core/Panel/Panel.module.css
+++ b/packages/desktop/src/renderer/components/core/Panel/Panel.module.css
@@ -6,10 +6,21 @@
   background-color: var(--bgColorDark2);
   box-shadow: 3px 3px 0 0 black;
 
-  &:global(.full) {
-    width: 100%;
-    height: 100%;
+  &:global(.bottom) {
+    border-radius: 0;
+    box-shadow: none;
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
   }
+}
+
+.heightFull {
+  height: 100%;
+}
+
+.widthFull {
+  width: 100%;
 }
 
 .header {
@@ -42,4 +53,22 @@
 
 .button {
   margin-left: auto;
+}
+
+.slim {
+  .body,
+  .header {
+    padding: var(--gapLarge);
+  }
+
+  .header {
+    .icon {
+      font-size: 1rem;
+      margin-right: var(--gapSmall);
+    }
+
+    h2 {
+      font-size: 1rem;
+    }
+  }
 }

--- a/packages/desktop/src/renderer/components/core/Panel/Panel.tsx
+++ b/packages/desktop/src/renderer/components/core/Panel/Panel.tsx
@@ -75,13 +75,15 @@ export const PanelHeader = ({
   </div>
 )
 
-export interface PanelBodyProps {
+export interface PanelBodyProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   scrollable?: boolean
 }
 
-export const PanelBody = ({ children, scrollable }: PanelBodyProps) => (
-  <div className={`${c.body} ${scrollable && 'scrollable'}`}>{children}</div>
+export const PanelBody = ({ children, scrollable, className }: PanelBodyProps) => (
+  <div className={`themeLevel1 ${c.body} ${scrollable && 'scrollable'} ${className}`}>
+    {children}
+  </div>
 )
 
 export interface PanelActionsProps {

--- a/packages/desktop/src/renderer/components/core/Panel/Panel.tsx
+++ b/packages/desktop/src/renderer/components/core/Panel/Panel.tsx
@@ -4,10 +4,22 @@ import { Button } from '@components/core/Button/Button'
 import { Icon, IconName } from '@components/core/Icon/Icon'
 
 export interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {
-  size?: 'full'
+  width?: 'full'
+  height?: 'full'
+  snugPosition?: 'bottom'
+  spacing?: 'slim'
 }
 
-export const Panel = ({ children, size, className, onClick, ...props }: PanelProps) => {
+export const Panel = ({
+  children,
+  width,
+  height,
+  className,
+  snugPosition,
+  spacing,
+  onClick,
+  ...props
+}: PanelProps) => {
   const onClickHandler = useCallback<MouseEventHandler<HTMLDivElement>>(
     (e) => {
       e.stopPropagation()
@@ -17,7 +29,18 @@ export const Panel = ({ children, size, className, onClick, ...props }: PanelPro
   )
 
   return (
-    <div onClick={onClickHandler} className={`${c.wrapper} ${size} ${className}`} {...props}>
+    <div
+      onClick={onClickHandler}
+      className={`
+        ${c.wrapper}
+        ${className}
+        ${snugPosition}
+        ${width === 'full' && c.widthFull}
+        ${height === 'full' && c.heightFull}
+        ${spacing === 'slim' && c.slim}
+      `}
+      {...props}
+    >
       {children}
     </div>
   )

--- a/packages/desktop/src/renderer/components/hooks/useActiveSketchParams.ts
+++ b/packages/desktop/src/renderer/components/hooks/useActiveSketchParams.ts
@@ -1,27 +1,30 @@
 import { useMemo } from 'react'
-import { Param } from '@hedron/engine'
+import { ParamWithInfo } from '@hedron/engine'
 import { useActiveSketch } from '@components/hooks/useActiveSketch'
 import { useEngineStore } from '@renderer/engine'
 
-export type ParamWithInfo = Param & { title: string | undefined }
-
 export const useActiveSketchParams = () => {
   const activeSketch = useActiveSketch()
-  const nodes = useEngineStore((state) => state.nodes)
-  const module = useEngineStore(
-    (state) => activeSketch && state.sketchModules[activeSketch.moduleId],
-  )
 
-  const params: ParamWithInfo[] = useMemo(() => {
-    if (activeSketch) {
-      return activeSketch.paramIds.map((id, index) => {
+  if (!activeSketch) {
+    throw new Error('useActiveSketchParams hook: No active sketch found')
+  }
+
+  const [nodes, module] = useEngineStore((state) => [
+    state.nodes,
+    state.sketchModules[activeSketch.moduleId],
+  ])
+
+  const params: ParamWithInfo[] = useMemo(
+    () =>
+      activeSketch.paramIds.map((id, index) => {
         const node = nodes[id]
-        const title = module?.config.params[index]?.title
+        const paramConfig = module?.config.params[index]
+        const title = paramConfig?.title ?? paramConfig?.key
         return { ...node, title }
-      })
-    }
-    return []
-  }, [activeSketch, nodes, module])
+      }),
+    [activeSketch, nodes, module],
+  )
 
   return params
 }

--- a/packages/desktop/src/renderer/components/hooks/useSelectedParam.ts
+++ b/packages/desktop/src/renderer/components/hooks/useSelectedParam.ts
@@ -1,8 +1,7 @@
-import { getParamWithInfo } from '@hedron/engine'
+import { getParamWithInfo, ParamWithInfo } from '@hedron/engine'
 import { useAppStore } from '@renderer/appStore'
 import { useActiveSketch } from '@components/hooks/useActiveSketch'
 import { useEngineStore } from '@renderer/engine'
-import { ParamWithInfo } from '@components/hooks/useActiveSketchParams'
 
 export const useSelectedParam = (): ParamWithInfo | null => {
   const activeSketch = useActiveSketch()

--- a/packages/desktop/src/renderer/components/hooks/useSelectedParam.ts
+++ b/packages/desktop/src/renderer/components/hooks/useSelectedParam.ts
@@ -1,0 +1,16 @@
+import { getParamWithInfo } from '@hedron/engine'
+import { useAppStore } from '@renderer/appStore'
+import { useActiveSketch } from '@components/hooks/useActiveSketch'
+import { useEngineStore } from '@renderer/engine'
+import { ParamWithInfo } from '@components/hooks/useActiveSketchParams'
+
+export const useSelectedParam = (): ParamWithInfo | null => {
+  const activeSketch = useActiveSketch()
+
+  if (!activeSketch) {
+    throw new Error('useSelectedParam hook: No active sketch found')
+  }
+
+  const selectedNodeId = useAppStore((state) => state.selectedNodes[activeSketch.id])
+  return useEngineStore(getParamWithInfo(selectedNodeId))
+}

--- a/packages/desktop/src/stories/Dialog.stories.tsx
+++ b/packages/desktop/src/stories/Dialog.stories.tsx
@@ -92,7 +92,7 @@ export const WithScroll = () => {
       </div>
       {!isHidden && (
         <Dialog>
-          <Panel size="full" style={{ maxWidth: '60rem' }}>
+          <Panel width="full" height="full" style={{ maxWidth: '60rem' }}>
             <PanelHeader iconName={sketchIcon} buttonOnClick={() => setIsHidden(true)}>
               Add Sketch To Scene
             </PanelHeader>

--- a/packages/desktop/src/stories/NodeControl.stories.tsx
+++ b/packages/desktop/src/stories/NodeControl.stories.tsx
@@ -13,6 +13,7 @@ import { ControlGrid } from '@components/core/ControlGrid/ControlGrid'
 
 import { FloatSlider, FloatSliderHandle } from '@components/core/FloatSlider/FloatSlider'
 import { BooleanToggle, BooleanToggleHandle } from '@components/core/BooleanToggle/BooleanToggle'
+import { Panel, PanelBody, PanelHeader } from '@components/core/Panel/Panel'
 
 const meta = {
   title: 'NodeControl',
@@ -24,17 +25,18 @@ export default meta
 interface BasicProps {
   title: string
   isActive?: boolean
+  color?: 'light'
   onClick: () => void
 }
 
-export const Number = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
+export const Number = ({ title = 'Short Name', color, isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useInterval(() => {
     ref.current!.drawBar(Math.random())
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick}>
+    <NodeControl isActive={isActive} onClick={onClick} color={color}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -45,14 +47,14 @@ export const Number = ({ title = 'Short Name', isActive, onClick }: BasicProps) 
   )
 }
 
-export const Boolean = ({ title = 'Boolean Thing', isActive, onClick }: BasicProps) => {
+export const Boolean = ({ title = 'Boolean Thing', isActive, color, onClick }: BasicProps) => {
   const ref = useRef<BooleanToggleHandle>(null)
 
   useInterval(() => {
     ref.current!.setChecked(Math.random() > 0.5)
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick}>
+    <NodeControl isActive={isActive} onClick={onClick} color={color}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -74,18 +76,43 @@ const params = [
   'another long param',
 ]
 
-export const WithControlGrid = () => {
+interface GridProps {
+  color?: 'light'
+}
+
+export const WithControlGrid = ({ color }: GridProps) => {
   const [activeId, setActiveId] = useState(0)
 
   return (
     <ControlGrid>
       {params.map((item, i) =>
         i % 2 == 0 ? (
-          <Number key={i} title={item} isActive={activeId === i} onClick={() => setActiveId(i)} />
+          <Number
+            key={i}
+            title={item}
+            isActive={activeId === i}
+            onClick={() => setActiveId(i)}
+            color={color}
+          />
         ) : (
-          <Boolean key={i} title={item} isActive={activeId === i} onClick={() => setActiveId(i)} />
+          <Boolean
+            key={i}
+            title={item}
+            isActive={activeId === i}
+            onClick={() => setActiveId(i)}
+            color={color}
+          />
         ),
       )}
     </ControlGrid>
   )
 }
+
+export const GridOnPanel = () => (
+  <Panel spacing="slim">
+    <PanelHeader iconName="power">Foo Bar</PanelHeader>
+    <PanelBody>
+      <WithControlGrid color="light" />
+    </PanelBody>
+  </Panel>
+)

--- a/packages/desktop/src/stories/NodeControl.stories.tsx
+++ b/packages/desktop/src/stories/NodeControl.stories.tsx
@@ -29,14 +29,14 @@ interface BasicProps {
   onClick: () => void
 }
 
-export const Number = ({ title = 'Short Name', color, isActive, onClick }: BasicProps) => {
+export const Number = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useInterval(() => {
     ref.current!.drawBar(Math.random())
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick} color={color}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -47,14 +47,14 @@ export const Number = ({ title = 'Short Name', color, isActive, onClick }: Basic
   )
 }
 
-export const Boolean = ({ title = 'Boolean Thing', isActive, color, onClick }: BasicProps) => {
+export const Boolean = ({ title = 'Boolean Thing', isActive, onClick }: BasicProps) => {
   const ref = useRef<BooleanToggleHandle>(null)
 
   useInterval(() => {
     ref.current!.setChecked(Math.random() > 0.5)
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick} color={color}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -76,32 +76,16 @@ const params = [
   'another long param',
 ]
 
-interface GridProps {
-  color?: 'light'
-}
-
-export const WithControlGrid = ({ color }: GridProps) => {
+export const WithControlGrid = () => {
   const [activeId, setActiveId] = useState(0)
 
   return (
     <ControlGrid>
       {params.map((item, i) =>
         i % 2 == 0 ? (
-          <Number
-            key={i}
-            title={item}
-            isActive={activeId === i}
-            onClick={() => setActiveId(i)}
-            color={color}
-          />
+          <Number key={i} title={item} isActive={activeId === i} onClick={() => setActiveId(i)} />
         ) : (
-          <Boolean
-            key={i}
-            title={item}
-            isActive={activeId === i}
-            onClick={() => setActiveId(i)}
-            color={color}
-          />
+          <Boolean key={i} title={item} isActive={activeId === i} onClick={() => setActiveId(i)} />
         ),
       )}
     </ControlGrid>
@@ -112,7 +96,7 @@ export const GridOnPanel = () => (
   <Panel spacing="slim">
     <PanelHeader iconName="power">Foo Bar</PanelHeader>
     <PanelBody>
-      <WithControlGrid color="light" />
+      <WithControlGrid />
     </PanelBody>
   </Panel>
 )

--- a/packages/desktop/src/stories/Panel.stories.tsx
+++ b/packages/desktop/src/stories/Panel.stories.tsx
@@ -199,7 +199,7 @@ export const BottomPanel: Story = {
           Position X Input
         </PanelHeader>
         <PanelBody>
-          <WithControlGrid color="light" />
+          <WithControlGrid />
         </PanelBody>
       </Panel>
     )

--- a/packages/desktop/src/stories/Panel.stories.tsx
+++ b/packages/desktop/src/stories/Panel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { fn } from '@storybook/test'
+import { WithControlGrid } from './NodeControl.stories'
 import { Panel, PanelActions, PanelBody, PanelHeader } from '@components/core/Panel/Panel'
 import { Button } from '@components/core/Button/Button'
 
@@ -57,7 +58,7 @@ export const Scrollable: Story = {
   ],
   render: () => {
     return (
-      <Panel size="full">
+      <Panel height="full">
         <PanelHeader iconName="info">Welcome to the panel!</PanelHeader>
         <PanelBody scrollable>
           <p>
@@ -112,7 +113,7 @@ export const ScrollableWithoutActions: Story = {
   ],
   render: () => {
     return (
-      <Panel size="full">
+      <Panel height="full">
         <PanelHeader iconName="info">Welcome to the panel!</PanelHeader>
         <PanelBody scrollable>
           <p>
@@ -166,6 +167,39 @@ export const WithCloseButton: Story = {
             voluptatum quidem minus atque, numquam explicabo blanditiis ad corporis eligendi
             delectus, incidunt ipsum harum error. Quidem dolorem exercitationem nostrum dignissimos!
           </p>
+        </PanelBody>
+      </Panel>
+    )
+  },
+}
+
+export const BottomPanel: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div
+          style={{
+            height: '100vh',
+            display: 'flex',
+            alignItems: 'flex-end',
+          }}
+        >
+          <Story />
+        </div>
+      )
+    },
+  ],
+  render: () => {
+    return (
+      <Panel snugPosition="bottom" spacing="slim" width="full">
+        <PanelHeader iconName="power" buttonOnClick={fn()}>
+          Position X Input
+        </PanelHeader>
+        <PanelBody>
+          <WithControlGrid />
         </PanelBody>
       </Panel>
     )

--- a/packages/desktop/src/stories/Panel.stories.tsx
+++ b/packages/desktop/src/stories/Panel.stories.tsx
@@ -199,7 +199,7 @@ export const BottomPanel: Story = {
           Position X Input
         </PanelHeader>
         <PanelBody>
-          <WithControlGrid />
+          <WithControlGrid color="light" />
         </PanelBody>
       </Panel>
     )

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,5 @@
 export * from './HedronEngine'
 export type * from '@store/types'
 export * from '@store/types'
+export { getParamWithInfo } from '@store/selectors/getParamWithInfo'
 import './globalVars'

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,5 @@
 export * from './HedronEngine'
 export type * from '@store/types'
 export * from '@store/types'
-export { getParamWithInfo } from '@store/selectors/getParamWithInfo'
+export { getParamWithInfo, ParamWithInfo } from '@store/selectors/getParamWithInfo'
 import './globalVars'

--- a/packages/engine/src/store/selectors/getParamWithInfo.ts
+++ b/packages/engine/src/store/selectors/getParamWithInfo.ts
@@ -1,0 +1,22 @@
+import { EngineState, Param } from '@store/types'
+
+export type ParamWithInfo = Param & { title: string }
+
+export const getParamWithInfo =
+  (paramId: string) =>
+  (state: EngineState): ParamWithInfo | null => {
+    const param = state.nodes[paramId]
+    if (!param) return null
+
+    const sketch = state.sketches[param.sketchId]
+    if (!sketch) return null
+
+    const module = state.sketchModules[sketch.moduleId]
+    if (!module) return null
+
+    const paramIndex = sketch.paramIds.indexOf(paramId)
+    const paramConfig = module.config.params[paramIndex]
+    const title = paramConfig?.title ?? paramConfig?.key
+
+    return { ...param, title }
+  }


### PR DESCRIPTION
Adds some variants to the `Panel` component so it can be used as a bottom panel (e.g. param details on the sketch view). 

- [x] Create component variations
- [x] Consider CSS parent override vars for theming instead of props...
- [x] Implement as empty panel opening in sketch view