### PR TITLE
Fix node click

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "lerna run dev --parallel",
+    "storybook": "lerna run storybook --scope @hedron/desktop",
     "build:engine": "lerna run build --scope @hedron/engine",
     "build": "lerna run build",
     "typecheck": "lerna run typecheck",

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import c from './NodeControl.module.css'
 
 export interface NodeControlProps {
@@ -36,5 +36,13 @@ export interface NodeControlInnerProps {
 }
 
 export const NodeControlInner = ({ children }: NodeControlInnerProps) => {
-  return <div className={c.inner}>{children}</div>
+  const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <div className={c.inner} onClick={handleClick}>
+      {children}
+    </div>
+  )
 }

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef, createContext, useContext, useEffect } from 'react'
 import c from './NodeControl.module.css'
 
 export interface NodeControlProps {
@@ -7,11 +7,23 @@ export interface NodeControlProps {
   onClick?: () => void
 }
 
+const MouseDownContext = createContext<React.MutableRefObject<boolean> | null>(null)
+
 export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) => {
+  const isMouseDown = useRef(false)
+
+  const handleClick = useCallback(() => {
+    if (!isMouseDown.current) {
+      onClick?.()
+    }
+  }, [onClick])
+
   return (
-    <div onClick={onClick} className={`${c.wrapper} ${isActive && 'active'}`}>
-      {children}
-    </div>
+    <MouseDownContext.Provider value={isMouseDown}>
+      <div onClick={handleClick} className={`${c.wrapper} ${isActive && 'active'}`}>
+        {children}
+      </div>
+    </MouseDownContext.Provider>
   )
 }
 
@@ -36,12 +48,38 @@ export interface NodeControlInnerProps {
 }
 
 export const NodeControlInner = ({ children }: NodeControlInnerProps) => {
+  const isMouseDown = useContext(MouseDownContext)
+
+  const handleMouseDown = useCallback(() => {
+    if (isMouseDown) {
+      isMouseDown.current = true
+    }
+  }, [isMouseDown])
+
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
   }, [])
 
+  useEffect(() => {
+    const handleDocumentMouseUp = () => {
+      if (isMouseDown) {
+        setTimeout(() => {
+          isMouseDown.current = false
+        }, 0)
+      }
+    }
+
+    // Add global mouseup listener
+    document.addEventListener('mouseup', handleDocumentMouseUp)
+
+    // Cleanup listener on component unmount
+    return () => {
+      document.removeEventListener('mouseup', handleDocumentMouseUp)
+    }
+  }, [isMouseDown])
+
   return (
-    <div className={c.inner} onClick={handleClick}>
+    <div className={c.inner} onClick={handleClick} onMouseDown={handleMouseDown}>
       {children}
     </div>
   )

--- a/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/NodeControl.tsx
@@ -1,5 +1,10 @@
-import React, { useCallback, useRef, createContext, useContext, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import c from './NodeControl.module.css'
+import {
+  MouseDownContext,
+  useWasMouseDownOnInnerContext,
+  useMouseDownOnInner,
+} from './wasMouseDownOnInner'
 
 export interface NodeControlProps {
   isActive?: boolean
@@ -7,19 +12,18 @@ export interface NodeControlProps {
   onClick?: () => void
 }
 
-const MouseDownContext = createContext<React.MutableRefObject<boolean> | null>(null)
-
 export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) => {
-  const isMouseDown = useRef(false)
+  const wasMouseDownOnInner = useWasMouseDownOnInnerContext()
 
   const handleClick = useCallback(() => {
-    if (!isMouseDown.current) {
+    // Disable click event if mouse down started on inner
+    if (!wasMouseDownOnInner.current) {
       onClick?.()
     }
-  }, [onClick])
+  }, [wasMouseDownOnInner, onClick])
 
   return (
-    <MouseDownContext.Provider value={isMouseDown}>
+    <MouseDownContext.Provider value={wasMouseDownOnInner}>
       <div onClick={handleClick} className={`${c.wrapper} ${isActive && 'active'}`}>
         {children}
       </div>
@@ -48,35 +52,12 @@ export interface NodeControlInnerProps {
 }
 
 export const NodeControlInner = ({ children }: NodeControlInnerProps) => {
-  const isMouseDown = useContext(MouseDownContext)
-
-  const handleMouseDown = useCallback(() => {
-    if (isMouseDown) {
-      isMouseDown.current = true
-    }
-  }, [isMouseDown])
+  // Register mouse down on inner so click can be disabled if mouse is released outside of this component
+  const handleMouseDown = useMouseDownOnInner()
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
   }, [])
-
-  useEffect(() => {
-    const handleDocumentMouseUp = () => {
-      if (isMouseDown) {
-        setTimeout(() => {
-          isMouseDown.current = false
-        }, 0)
-      }
-    }
-
-    // Add global mouseup listener
-    document.addEventListener('mouseup', handleDocumentMouseUp)
-
-    // Cleanup listener on component unmount
-    return () => {
-      document.removeEventListener('mouseup', handleDocumentMouseUp)
-    }
-  }, [isMouseDown])
 
   return (
     <div className={c.inner} onClick={handleClick} onMouseDown={handleMouseDown}>

--- a/packages/desktop/src/renderer/components/core/NodeControl/wasMouseDownOnInner.tsx
+++ b/packages/desktop/src/renderer/components/core/NodeControl/wasMouseDownOnInner.tsx
@@ -1,0 +1,42 @@
+/*
+  These hooks are used to disable clicks on a parent component if some inner component was first clicked.
+  e.g. we don't want to select a node if we are dragging a slider inside the node, and the mouse is released outside the slider.
+*/
+
+import React, { useRef, createContext, useEffect, useContext, useCallback } from 'react'
+
+export const MouseDownContext = createContext<React.MutableRefObject<boolean> | null>(null)
+
+export const useWasMouseDownOnInnerContext = () => {
+  const isMouseDown = useRef(false)
+  useEffect(() => {
+    const handleDocumentMouseUp = () => {
+      if (isMouseDown) {
+        // Wait for the next frame to set isMouseDown to false so the flag can be used in the click event
+        requestAnimationFrame(() => {
+          isMouseDown.current = false
+        })
+      }
+    }
+
+    document.addEventListener('mouseup', handleDocumentMouseUp)
+
+    return () => {
+      document.removeEventListener('mouseup', handleDocumentMouseUp)
+    }
+  }, [isMouseDown])
+
+  return isMouseDown
+}
+
+export const useMouseDownOnInner = () => {
+  const isMouseDownOnInner = useContext(MouseDownContext)
+
+  const handleMouseDown = useCallback(() => {
+    if (isMouseDownOnInner) {
+      isMouseDownOnInner.current = true
+    }
+  }, [isMouseDownOnInner])
+
+  return handleMouseDown
+}


### PR DESCRIPTION
Using a param slider was also selecting that param. This is undesired behaviour. This PR introduces two fixes:

- Using any node control (slider, color picker, etc) does not select the node
- Dragging outside of a slider and onto a node does not select the node