### PR TITLE
Basic Midi Support

### DIFF
--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -8,6 +8,7 @@ import { Card, CardActions } from '@components/core/Card/Card'
 import { Icon, paramIcon } from '@components/core/Icon/Icon'
 import { Panel, PanelBody, PanelHeader } from '@components/core/Panel/Panel'
 import { useSelectedParam } from '@components/hooks/useSelectedParam'
+import { MidiSetting } from '@components/MidiSetting/MidiSetting'
 
 export const ActiveSketch = () => {
   const activeSketch = useActiveSketch()
@@ -40,7 +41,9 @@ export const ActiveSketch = () => {
       {selectedParam && (
         <Panel snugPosition="bottom" spacing="slim" width="full" className={c.bottomPanel}>
           <PanelHeader iconName={paramIcon}>{selectedParam.title}</PanelHeader>
-          <PanelBody>:)</PanelBody>
+          <PanelBody>
+            <MidiSetting param={selectedParam} />
+          </PanelBody>
         </Panel>
       )}
     </>

--- a/packages/desktop/src/renderer/components/MidiSetting/MidiSetting.tsx
+++ b/packages/desktop/src/renderer/components/MidiSetting/MidiSetting.tsx
@@ -1,0 +1,39 @@
+import { NodeTypes, ParamWithInfo } from '@hedron/engine'
+import { useInputsWithNode } from '@components/hooks/useInput'
+import { engine } from '@renderer/engine'
+
+interface ParamMidiSetting {
+  param: ParamWithInfo
+}
+
+export const MidiSetting = ({ param }: ParamMidiSetting) => {
+  const inputs = useInputsWithNode(param.id)
+  if (param.valueType !== NodeTypes.Number) {
+    return
+  }
+
+  async function useMidiLearn() {
+    await engine.midiLearn(param.id)
+  }
+
+  function removeMidi(id: string) {
+    return () => {
+      engine.deleteInputParam(id, param.id)
+    }
+  }
+
+  return (
+    <>
+      {param.id} - {param.valueType}
+      {inputs.map((input) => (
+        <div key={input.id}>
+          {input.id} - {input.type}
+          <button onClick={removeMidi(input.id)}>Remove</button>
+        </div>
+      ))}
+      <div>
+        <button onClick={useMidiLearn}>Midi Learn</button>
+      </div>
+    </>
+  )
+}

--- a/packages/desktop/src/renderer/components/hooks/useInput.ts
+++ b/packages/desktop/src/renderer/components/hooks/useInput.ts
@@ -1,0 +1,11 @@
+import { useEngineStore } from '@renderer/engine'
+
+export const useInput = (id: string) => {
+  const inputs = useEngineStore((state) => state.inputs)
+  return inputs[id]
+}
+
+export const useInputsWithNode = (nodeId: string) => {
+  const inputs = useEngineStore((state) => state.inputs)
+  return Object.values(inputs).filter((input) => input.targetNodeIds.includes(nodeId))
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -28,6 +28,7 @@
     "three": "*"
   },
   "dependencies": {
+    "@hedron/midi": "^1.0.0-alpha.0",
     "lodash.debounce": "^4.0.8",
     "uid": "^2.0.2",
     "zustand": "^5.0.2"

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -1,3 +1,4 @@
+import { Midi, MIDIEvent } from '@hedron/midi'
 import { listenToStore } from './storeListener'
 import { Result } from './types'
 import { importSketchModule } from './importSketchModule'
@@ -5,7 +6,7 @@ import { stripForSave } from '@utils/stripForSave'
 import { Renderer } from '@world/Renderer'
 import { SketchManager } from '@world/SketchManager'
 import { createDebugScene } from '@world/debugScene'
-import { EngineData, SketchModuleItem } from '@store/types'
+import { EngineData, Input, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
 import { createEngineStore, EngineStore } from '@store/engineStore'
 import { getSketchParamValues } from '@store/selectors/getSketchParamValues'
@@ -15,11 +16,49 @@ export class HedronEngine {
   private store: EngineStore
   private sketchesUrl: string | null = null
   private sketchManager: SketchManager
+  private midi: Midi
 
   constructor() {
     this.store = createEngineStore()
     this.sketchManager = new SketchManager()
     this.renderer = new Renderer()
+    this.midi = new Midi()
+    this.midi.onMidiMessage.add((event) => {
+      const id = `${event.device.name} - ${event.message.data?.[1]}`.replace(/ /g, '_')
+      this.store.getState().updateInputValues(id, (event.message.data?.[2] || 0) / 127)
+    }, this)
+  }
+
+  public async awaitNextMidiMessage(): Promise<MIDIEvent | null> {
+    // null response would be canceling the midi learn, but that is not hooked up yet as there is no GUI
+    return new Promise((resolve) => {
+      const listener = (event: MIDIEvent) => {
+        this.midi.onMidiMessage.remove(listener)
+        resolve(event)
+      }
+      this.midi.onMidiMessage.add(listener)
+    })
+  }
+
+  public async midiLearn(paramId: string): Promise<Input> {
+    const event = await this.awaitNextMidiMessage()
+    if (!event) {
+      throw new Error('No MIDI event received')
+    }
+
+    const id = `${event.device.name} - ${event.message.data?.[1]}`.replace(/ /g, '_')
+    let input = this.store.getState().inputs[id]
+    if (!input) {
+      input = {
+        id,
+        type: 'midi',
+        targetNodeIds: [paramId],
+      }
+      this.store.getState().addInput(id, input)
+      return input
+    }
+    this.store.getState().addInputParam(id, paramId)
+    return input
   }
 
   public setSketchesUrl(sketchesUrl: string) {
@@ -100,6 +139,10 @@ export class HedronEngine {
 
   public getSaveData(): EngineData {
     return stripForSave(this.store.getState())
+  }
+
+  public deleteInputParam(inputId: string, nodeId: string) {
+    this.store.getState().deleteInputParam(inputId, nodeId)
   }
 
   run() {

--- a/packages/engine/src/store/actionCreators/createAddInput.ts
+++ b/packages/engine/src/store/actionCreators/createAddInput.ts
@@ -1,0 +1,31 @@
+import { Input, SetterCreator } from '@store/types'
+
+export const createAddInput: SetterCreator<'addInput'> =
+  (setState) => (inputId: string, value: Input) => {
+    setState((state) => {
+      if (state.inputs[inputId]) {
+        return
+      }
+      state.inputs[inputId] = value
+    })
+  }
+
+export const createAddInputParam: SetterCreator<'addInputParam'> =
+  (setState) => (inputId: string, nodeId: string) => {
+    setState((state) => {
+      const input = state.inputs[inputId]
+      if (input) {
+        input.targetNodeIds.push(nodeId)
+      }
+    })
+  }
+
+export const createDeleteInputParam: SetterCreator<'deleteInputParam'> =
+  (setState) => (inputId: string, nodeId: string) => {
+    setState((state) => {
+      const input = state.inputs[inputId]
+      if (input) {
+        input.targetNodeIds = input.targetNodeIds.filter((id) => id !== nodeId)
+      }
+    })
+  }

--- a/packages/engine/src/store/actionCreators/createUpdateInputValues.ts
+++ b/packages/engine/src/store/actionCreators/createUpdateInputValues.ts
@@ -1,0 +1,16 @@
+import { NodeValue, SetterCreator } from '@store/types'
+
+export const createUpdateInputValues: SetterCreator<'updateInputValues'> =
+  (setState) => (inputId: string, value: NodeValue) => {
+    setState((state) => {
+      const input = state.inputs[inputId]
+      if (!input) {
+        //throw new Error(`Input with id ${inputId} not found.`)
+        return
+      }
+
+      input.targetNodeIds.forEach((nodeId) => {
+        state.nodeValues[nodeId] = value
+      })
+    })
+  }

--- a/packages/engine/src/store/engineStore.ts
+++ b/packages/engine/src/store/engineStore.ts
@@ -13,6 +13,12 @@ import { createUpdateSketchParams } from '@store/actionCreators/updateSketchPara
 import { createUpdateNodeValue } from '@store/actionCreators/updateNodeValue'
 import { createReset } from '@store/actionCreators/reset'
 import { createLoadProject } from '@store/actionCreators/loadProject'
+import { createUpdateInputValues } from '@store/actionCreators/createUpdateInputValues'
+import {
+  createAddInput,
+  createAddInputParam,
+  createDeleteInputParam,
+} from '@store/actionCreators/createAddInput'
 
 export const createEngineStore = () =>
   createStore<EngineStateWithActions>()(
@@ -28,6 +34,10 @@ export const createEngineStore = () =>
           deleteSketchModule: createDeleteSketchModule(set),
           reset: createReset(set),
           loadProject: createLoadProject(set),
+          updateInputValues: createUpdateInputValues(set),
+          addInput: createAddInput(set),
+          deleteInputParam: createDeleteInputParam(set),
+          addInputParam: createAddInputParam(set),
         })),
       ),
     ),

--- a/packages/engine/src/store/initialState.ts
+++ b/packages/engine/src/store/initialState.ts
@@ -6,4 +6,5 @@ export const initialState: EngineState = {
   nodes: {},
   nodeValues: {},
   sketchModules: {},
+  inputs: {},
 }

--- a/packages/engine/src/store/types.ts
+++ b/packages/engine/src/store/types.ts
@@ -135,10 +135,19 @@ export type SketchModules = { [key: string]: SketchModuleItem }
 
 export type EnumOption = { value: string; label: string }
 
+export interface Input {
+  id: string
+  type: 'midi' | 'gamepad' | string
+  targetNodeIds: string[]
+}
+
+export type Inputs = { [key: string]: Input }
+
 export interface EngineData {
   sketches: Sketches
   nodes: Nodes
   nodeValues: NodeValues
+  inputs: Inputs
 }
 
 interface AuxState {
@@ -157,6 +166,10 @@ interface Actions {
   deleteSketchModule: (moduleId: string) => void
   loadProject: (project: EngineData) => void
   reset: () => void
+  addInput: (inputId: string, value: Input) => void
+  deleteInputParam: (inputId: string, paramId: string) => void
+  updateInputValues: (inputId: string, value: NodeValue) => void
+  addInputParam: (inputId: string, paramId: string) => void
 }
 
 export type EngineStateWithActions = EngineData & AuxState & Actions

--- a/packages/midi-test-app/.eslintignore
+++ b/packages/midi-test-app/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/midi-test-app/.eslintrc.cjs
+++ b/packages/midi-test-app/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  extends: '../../.eslintrc.cjs',
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
+      },
+      node: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
+}

--- a/packages/midi-test-app/README.md
+++ b/packages/midi-test-app/README.md
@@ -1,0 +1,50 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+
+- Configure the top-level `parserOptions` property like this:
+
+```js
+export default tseslint.config({
+  languageOptions: {
+    // other options...
+    parserOptions: {
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+})
+```
+
+- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
+- Optionally add `...tseslint.configs.stylisticTypeChecked`
+- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+
+```js
+// eslint.config.js
+import react from 'eslint-plugin-react'
+
+export default tseslint.config({
+  // Set the react version
+  settings: { react: { version: '18.3' } },
+  plugins: {
+    // Add the react plugin
+    react,
+  },
+  rules: {
+    // other rules...
+    // Enable its recommended rules
+    ...react.configs.recommended.rules,
+    ...react.configs['jsx-runtime'].rules,
+  },
+})
+```

--- a/packages/midi-test-app/index.html
+++ b/packages/midi-test-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hedron Midi Test App</title>
+  </head>
+  <body>
+    <main class="container" id="root"></main>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/midi-test-app/package.json
+++ b/packages/midi-test-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@hedron/midi-test-app",
+  "version": "1.0.0-alpha.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@hedron/midi": "^1.0.0-alpha.0",
+    "@picocss/pico": "^2.0.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "globals": "^15.14.0",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/packages/midi-test-app/src/App.tsx
+++ b/packages/midi-test-app/src/App.tsx
@@ -1,0 +1,69 @@
+// import { FormEvent, useEffect, useState } from 'react'
+import './custom.css'
+import { Midi, MIDIEvent, MidiMessageType } from '@hedron/midi'
+
+const $text = (id: string, text: string) => {
+  document.querySelector<HTMLDivElement>(`#${id}`)!.textContent = text
+}
+
+function App() {
+  // const [mockBpm, setMockBpm] = useState(DEFAULT_BPM)
+
+  const midiLogs: string[] = []
+
+  function onMidiMessage({ device, message }: MIDIEvent) {
+    if (!message.data) {
+      console.error('No data in MIDI message:', message)
+      return
+    }
+    const status = message.data[0]
+    const statusType = midi.getMidiMessageType(status)
+    if (statusType === MidiMessageType.Unknown) {
+      return // my launch pad was sending unknown non-stop, would imagine some other devices do as well
+    }
+    const data1 = message.data[1]
+    const data2 = message.data[2]
+    midiLogs.unshift(`${device.name}: \t${status.toString(16)}(${statusType}): \t${data1} ${data2}`)
+    if (midiLogs.length > 16) {
+      midiLogs.pop()
+    }
+    $text('logs', midiLogs.join('\n'))
+  }
+
+  function onDeviceChange() {
+    $text('devices', getMidiDevices())
+  }
+
+  const midi: Midi = new Midi()
+  // onDeviceChange()
+  midi.onDeviceChange.add(onDeviceChange)
+  midi.onMidiMessage.add(onMidiMessage)
+
+  function getMidiDevices(): string {
+    if (midi.devices.length === 0) {
+      return 'No MIDI devices found.'
+    }
+
+    return midi.devices
+      .map((device: MIDIInput) => {
+        return `Connected MIDI device: ${device.name}`
+      })
+      .join('\n')
+  }
+
+  return (
+    <>
+      <section>
+        <div className="grid">
+          <div>
+            <code>Midi Debug</code>
+            <div className="pre-wrap" id="devices"></div>
+            <code className="pre-wrap" id="logs"></code>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}
+
+export default App

--- a/packages/midi-test-app/src/custom.css
+++ b/packages/midi-test-app/src/custom.css
@@ -1,0 +1,3 @@
+.pre-wrap {
+  white-space: pre-wrap;
+}

--- a/packages/midi-test-app/src/main.tsx
+++ b/packages/midi-test-app/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App.tsx'
+import '@picocss/pico/css/pico.min.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/packages/midi-test-app/src/vite-env.d.ts
+++ b/packages/midi-test-app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/midi-test-app/tsconfig.app.json
+++ b/packages/midi-test-app/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/packages/midi-test-app/tsconfig.json
+++ b/packages/midi-test-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/packages/midi-test-app/tsconfig.node.json
+++ b/packages/midi-test-app/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/midi-test-app/vite.config.ts
+++ b/packages/midi-test-app/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})

--- a/packages/midi/.eslintrc.cjs
+++ b/packages/midi/.eslintrc.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: '../../.eslintrc.cjs',
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: './tsconfig.json',
+      },
+    },
+  },
+}

--- a/packages/midi/README.md
+++ b/packages/midi/README.md
@@ -1,0 +1,11 @@
+# `midi`
+
+> TODO: description
+
+## Usage
+
+```
+const midi = require('midi');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/midi/package.json
+++ b/packages/midi/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@hedron/midi",
+  "version": "1.0.0-alpha.0",
+  "description": "MIDI Module",
+  "author": "Alex Kempton <alex@funwithtriangles.net>",
+  "homepage": "https://github.com/nudibranchrecords/hedron#readme",
+  "license": "ISC",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nudibranchrecords/hedron.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nudibranchrecords/hedron/issues"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.6"
+  }
+}

--- a/packages/midi/src/Signal.ts.ts
+++ b/packages/midi/src/Signal.ts.ts
@@ -1,0 +1,53 @@
+type func<T> = (value: T) => void
+
+interface Listener<T> {
+  listener: func<T>
+  target?: unknown
+}
+
+/**
+ * A simple class for dispatching signals to multiple listeners.
+ */
+export class Signal<T> {
+  private _listeners: Listener<T>[] = []
+
+  /**
+   * Adds a listener to the signal.
+   * @param listener The function to call when the signal is dispatched.
+   * @param target The target to bind the listener to.
+   */
+  add(listener: func<T>, target?: unknown) {
+    this._listeners.push({ listener, target })
+  }
+
+  /**
+   * Removes a listener from the signal.
+   * @param listener The function to remove.
+   * @param target The target the listener was bound to.
+   */
+  remove(listener: func<T>, target?: unknown) {
+    if (target) {
+      this._listeners = this._listeners.filter(
+        (l) => l.listener !== listener && l.target !== target,
+      )
+    } else {
+      this._listeners = this._listeners.filter((l) => l.listener !== listener)
+    }
+  }
+
+  /**
+   * Removes all listeners bound to a target.
+   * @param target The target
+   */
+  removeAll(target: unknown) {
+    this._listeners = this._listeners.filter((l) => l.target !== target)
+  }
+
+  /**
+   * Dispatches the signal to all listeners.
+   * @param value The value to dispatch.
+   */
+  dispatch(value: T) {
+    this._listeners.forEach((l) => l.listener.call(l.target, value))
+  }
+}

--- a/packages/midi/src/index.ts
+++ b/packages/midi/src/index.ts
@@ -1,0 +1,167 @@
+import { Signal } from './Signal.ts'
+
+/**
+ * Common MIDI message types as human readable names.
+ */
+export enum MidiMessageType {
+  Clock = 'Clock',
+  Start = 'Start',
+  Continue = 'Continue',
+  Stop = 'Stop',
+  NoteOff = 'Note Off',
+  NoteOn = 'Note On',
+  PolyphonicKeyPressure = 'Polyphonic Key Pressure (Aftertouch)',
+  ControlChange = 'Control Change',
+  ProgramChange = 'Program Change',
+  ChannelPressure = 'Channel Pressure (Aftertouch)',
+  PitchBendChange = 'Pitch Bend Change',
+  Unknown = 'Unknown',
+}
+
+export type MIDIEvent = {
+  device: MIDIInput
+  message: MIDIMessageEvent
+}
+
+/**
+ * A class that handles MIDI input devices and messages.
+ */
+export class Midi {
+  /**
+   * The list of MIDI input devices connected to the system.
+   */
+  public devices: MIDIInput[] = []
+
+  /**
+   * The MIDI access object that allows for interaction with MIDI devices.
+   */
+  private midiAccess: MIDIAccess | null = null
+
+  /**
+   * A map of MIDI input devices to their event listeners.
+   */
+  private eventListeners: Map<MIDIInput, (event: MIDIMessageEvent) => void> = new Map()
+
+  /**
+   * A callback that is called when the list of MIDI devices changes.
+   */
+  public onDeviceChange: Signal<void> = new Signal<void>()
+
+  /**
+   * A callback that is called when a MIDI message is received.
+   */
+  public onMidiMessage: Signal<MIDIEvent> = new Signal<MIDIEvent>()
+
+  constructor() {
+    this.findMidiDevices()
+  }
+
+  /**
+   * Clears all MIDI event listeners from the devices.
+   */
+  private clearMidiEventListeners = (): void => {
+    this.devices.forEach((device) => {
+      const listener = this.eventListeners.get(device)
+      if (listener) {
+        device.removeEventListener('midimessage', listener)
+        this.eventListeners.delete(device)
+      }
+    })
+  }
+
+  /**
+   * Sets the list of MIDI devices connected to the system and adds event listeners to them.
+   * @param deviceList The list of MIDI devices to set.
+   */
+  private setDevices = (deviceList: MIDIInput[]): void => {
+    if (
+      this.devices.length === deviceList.length &&
+      this.devices.every((value, index) => value === deviceList[index])
+    ) {
+      return
+    }
+    this.clearMidiEventListeners()
+
+    this.devices = deviceList
+
+    // Add event listeners to new devices
+    this.devices.forEach((device: MIDIInput) => {
+      if (!this.eventListeners.has(device)) {
+        const listener = (message: MIDIMessageEvent) => {
+          this.onMidiMessage.dispatch({ device, message })
+        }
+        device.addEventListener('midimessage', listener)
+        this.eventListeners.set(device, listener)
+      }
+    })
+
+    this.onDeviceChange.dispatch()
+  }
+
+  /**
+   * Updates the list of MIDI devices connected to the system.
+   */
+  private updateDevices = (): void => {
+    this.setDevices(Array.from(this.midiAccess?.inputs.values() ?? []))
+  }
+
+  /**
+   * Finds all MIDI devices connected to the system, and sets up events listeners for both the devices and the midi access (add/remove).
+   * @returns A promise that resolves when the MIDI devices have been found.
+   */
+  public findMidiDevices = async (): Promise<void> => {
+    if (!navigator.requestMIDIAccess) {
+      console.error('Web MIDI API is not supported in this browser.')
+      return
+    }
+
+    try {
+      this.midiAccess = await navigator.requestMIDIAccess()
+      this.midiAccess.addEventListener('statechange', this.updateDevices)
+      this.updateDevices()
+    } catch (error) {
+      console.error('Failed to get MIDI access:', error)
+    }
+  }
+
+  /**
+   * Converts a MIDI status byte to a human readable message type.
+   * @param status The status byte of a MIDI message.
+   * @returns The human readable message type via the MidiMessageType enum.
+   */
+  public getMidiMessageType(status: number): MidiMessageType {
+    const messageType = status & 0xf0 // Mask the lower nibble to get the message type
+
+    switch (messageType) {
+      case 0xf0:
+        switch (status) {
+          case 0xf8:
+            return MidiMessageType.Clock
+          case 0xfa:
+            return MidiMessageType.Start
+          case 0xfb:
+            return MidiMessageType.Continue
+          case 0xfc:
+            return MidiMessageType.Stop
+          default:
+            return MidiMessageType.Unknown
+        }
+      case 0x80:
+        return MidiMessageType.NoteOff
+      case 0x90:
+        return MidiMessageType.NoteOn
+      case 0xa0:
+        return MidiMessageType.PolyphonicKeyPressure
+      case 0xb0:
+        return MidiMessageType.ControlChange
+      case 0xc0:
+        return MidiMessageType.ProgramChange
+      case 0xd0:
+        return MidiMessageType.ChannelPressure
+      case 0xe0:
+        return MidiMessageType.PitchBendChange
+      default:
+        return MidiMessageType.Unknown
+    }
+  }
+}

--- a/packages/midi/src/index.ts
+++ b/packages/midi/src/index.ts
@@ -18,6 +18,9 @@ export enum MidiMessageType {
   Unknown = 'Unknown',
 }
 
+/**
+ * A simple type that provides both the device and the message of a MIDI event.
+ */
 export type MIDIEvent = {
   device: MIDIInput
   message: MIDIMessageEvent

--- a/packages/midi/tsconfig.json
+++ b/packages/midi/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../tsconfig.json"],
+  "include": ["src/**/*"]
+}

--- a/packages/midi/tsup.config.ts
+++ b/packages/midi/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  sourcemap: true,
+  clean: true,
+  dts: true,
+  target: 'esnext',
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@hedron/midi-test-app@workspace:packages/midi-test-app":
+  version: 0.0.0-use.local
+  resolution: "@hedron/midi-test-app@workspace:packages/midi-test-app"
+  dependencies:
+    "@eslint/js": "npm:^9.17.0"
+    "@hedron/midi": "npm:^1.0.0-alpha.0"
+    "@picocss/pico": "npm:^2.0.6"
+    "@types/react": "npm:^18.3.18"
+    "@types/react-dom": "npm:^18.3.5"
+    "@vitejs/plugin-react": "npm:^4.3.4"
+    globals: "npm:^15.14.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:~5.6.2"
+    vite: "npm:^6.0.5"
+  languageName: unknown
+  linkType: soft
+
+"@hedron/midi@npm:^1.0.0-alpha.0, @hedron/midi@workspace:packages/midi":
+  version: 0.0.0-use.local
+  resolution: "@hedron/midi@workspace:packages/midi"
+  dependencies:
+    tsup: "npm:^8.3.6"
+  languageName: unknown
+  linkType: soft
+
 "@humanwhocodes/config-array@npm:^0.13.0":
   version: 0.13.0
   resolution: "@humanwhocodes/config-array@npm:0.13.0"
@@ -2240,9 +2266,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-actions@npm:8.5.1"
+"@storybook/addon-actions@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-actions@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     "@types/uuid": "npm:^9.0.1"
@@ -2250,173 +2276,173 @@ __metadata:
     polished: "npm:^4.2.2"
     uuid: "npm:^9.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/f3b704e962e5b409f48876001889d896a9a611ecb2f9249bb8fa40cb78b30f63b478210fd191f6f2cbebdf7bfc6b54cb23551723861a2a3efc0430f357e1f051
+    storybook: ^8.5.2
+  checksum: 10c0/d509b0d2b46ef9f6b96363b54198d7ac5176b45886e0c3c0109560dc6fd6e249782f3e056f42eb474870090b88ebfac61b1d70763b073d9406a4b8762852e756
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-backgrounds@npm:8.5.1"
+"@storybook/addon-backgrounds@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-backgrounds@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     memoizerific: "npm:^1.11.3"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/085e442750a8bd0036cf050211128616ae6258434f88cec3352bf2c85dc7cd00e5bb008d3e7472d3121d25565ffd2e94140e93dda4b155fb26f1a53b54564242
+    storybook: ^8.5.2
+  checksum: 10c0/7161b498542f911071ffbb66aab8c9281fae72daba23836a3ed174363b3933d20d08f7dac483d801f9368efaa8e5d253b53b26999a47422a9bac984764e1bedb
   languageName: node
   linkType: hard
 
-"@storybook/addon-controls@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-controls@npm:8.5.1"
+"@storybook/addon-controls@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-controls@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     dequal: "npm:^2.0.2"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/572cecff58ac3fe99ab896eab1e874e6c0154b87d73426fa2ebdff4060d230507d81abf09c59ed9b818976da1e6641d9a0715b12828edc6a7467cdea0c709525
+    storybook: ^8.5.2
+  checksum: 10c0/8e5ae4ddd8601191010d0ffc19e5309bbd5d28445c91a1087ad40f40358a2c47a3ec91c3049ba7f1b86092a53691eaad0804cd854cafec06d8737fad54cd5cd1
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-docs@npm:8.5.1"
+"@storybook/addon-docs@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-docs@npm:8.5.2"
   dependencies:
     "@mdx-js/react": "npm:^3.0.0"
-    "@storybook/blocks": "npm:8.5.1"
-    "@storybook/csf-plugin": "npm:8.5.1"
-    "@storybook/react-dom-shim": "npm:8.5.1"
+    "@storybook/blocks": "npm:8.5.2"
+    "@storybook/csf-plugin": "npm:8.5.2"
+    "@storybook/react-dom-shim": "npm:8.5.2"
     react: "npm:^16.8.0 || ^17.0.0 || ^18.0.0"
     react-dom: "npm:^16.8.0 || ^17.0.0 || ^18.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/c2a717b206b34c75dcf4f44dab7ff56a83be5ba7e0f0680ff19e590a051d5d7b1c236fae24104fca067eaee1541fccc8757c78cc07cb3cddb880deece2477099
+    storybook: ^8.5.2
+  checksum: 10c0/9de7187aca2e4fafdcebab283ff8910fbb9eb7bd0bb488106d544b3683e5508b826e87d7d08505128a0ec5780087cac1a6689e18dd58a88c5c0d728a51a398bf
   languageName: node
   linkType: hard
 
 "@storybook/addon-essentials@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/addon-essentials@npm:8.5.1"
+  version: 8.5.2
+  resolution: "@storybook/addon-essentials@npm:8.5.2"
   dependencies:
-    "@storybook/addon-actions": "npm:8.5.1"
-    "@storybook/addon-backgrounds": "npm:8.5.1"
-    "@storybook/addon-controls": "npm:8.5.1"
-    "@storybook/addon-docs": "npm:8.5.1"
-    "@storybook/addon-highlight": "npm:8.5.1"
-    "@storybook/addon-measure": "npm:8.5.1"
-    "@storybook/addon-outline": "npm:8.5.1"
-    "@storybook/addon-toolbars": "npm:8.5.1"
-    "@storybook/addon-viewport": "npm:8.5.1"
+    "@storybook/addon-actions": "npm:8.5.2"
+    "@storybook/addon-backgrounds": "npm:8.5.2"
+    "@storybook/addon-controls": "npm:8.5.2"
+    "@storybook/addon-docs": "npm:8.5.2"
+    "@storybook/addon-highlight": "npm:8.5.2"
+    "@storybook/addon-measure": "npm:8.5.2"
+    "@storybook/addon-outline": "npm:8.5.2"
+    "@storybook/addon-toolbars": "npm:8.5.2"
+    "@storybook/addon-viewport": "npm:8.5.2"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/c66c098776f4ee6da86236d209968520f444faf61830d600879e72e121161db79d093bc6bfef7fce4fce1e0487a0b99afa2d34c538bf438725fe624be6a96112
+    storybook: ^8.5.2
+  checksum: 10c0/b12df402412316919c93cd9173486ffe79c5ee08ab89738c81a00929b2d74206e2fc331cb82d70caf14f8eaa2b6bced3b492c0522d0687f28b6355774aa6160c
   languageName: node
   linkType: hard
 
-"@storybook/addon-highlight@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-highlight@npm:8.5.1"
+"@storybook/addon-highlight@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-highlight@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/28bd9c097ec2a2f78b189426939839315a5fce458eb3d13ab8b18ec5a32f3371761addb03cdf1f17c6c03f9c2c3fe419078fb5af6b8f002a4aef677d1d9f23f0
+    storybook: ^8.5.2
+  checksum: 10c0/c14d8ba34e980e9b334f83ac75a90957bda6069cea368d1dfa3f17b74b763048700a3dffd930a20e162ee5c01378c910da51dcafa508644e8b01351e5b442188
   languageName: node
   linkType: hard
 
 "@storybook/addon-interactions@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/addon-interactions@npm:8.5.1"
+  version: 8.5.2
+  resolution: "@storybook/addon-interactions@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/instrumenter": "npm:8.5.1"
-    "@storybook/test": "npm:8.5.1"
+    "@storybook/instrumenter": "npm:8.5.2"
+    "@storybook/test": "npm:8.5.2"
     polished: "npm:^4.2.2"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/3f78146ee98f99885c1698580364f6f3ae6dba1964cc60b7e755bde3abf97019534f1bfb62f3a1c534eb9a05ace75a4ba52a81e58e4b2d1d3599ea84543fd232
+    storybook: ^8.5.2
+  checksum: 10c0/6a491d06cee81b4e8e7af100582784e21d739d84d3ae76f4fe88a85c6974f886f6ee6b9032fc22ddcd08c110b01d36b318c455c38396c0d51feb49060953e5ed
   languageName: node
   linkType: hard
 
 "@storybook/addon-links@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/addon-links@npm:8.5.1"
+  version: 8.5.2
+  resolution: "@storybook/addon-links@npm:8.5.2"
   dependencies:
     "@storybook/csf": "npm:0.1.12"
     "@storybook/global": "npm:^5.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.5.1
+    storybook: ^8.5.2
   peerDependenciesMeta:
     react:
       optional: true
-  checksum: 10c0/dc1c9f6131b97997f11937c2c95ff51f875f0e4dbaa201de8e76e6163c8f70b0cbebf4d39f0e57edcb5fd9c51feb2318c00644b5dee2b4da9d8dca322be9d1c6
+  checksum: 10c0/60f29c2ff9bb1887cb84a81fb29af9dc8f24cb424210a2619dbda3ba361d40f7b799f6084780b4244714c5785d0dcd936303acda548e1d72f955411a0c668647
   languageName: node
   linkType: hard
 
-"@storybook/addon-measure@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-measure@npm:8.5.1"
+"@storybook/addon-measure@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-measure@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     tiny-invariant: "npm:^1.3.1"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/4707a71ece4207f7cf3b26cdf3f748b51764acc41d3b935c95077262d1e977b79a3dbbccb3d5c4e5cbd3df4f2cbc163182e41d5268b67376dbd76bf84b7463c3
+    storybook: ^8.5.2
+  checksum: 10c0/b59e5f92699a13150306ba84d9a5155488e5a62e156135e5c8444f47ce4aa3bb95a13250a28ce5a42a388225ad006b8e42b77938c7914faa7b3db3b721bd7b2b
   languageName: node
   linkType: hard
 
 "@storybook/addon-onboarding@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/addon-onboarding@npm:8.5.1"
+  version: 8.5.2
+  resolution: "@storybook/addon-onboarding@npm:8.5.2"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/3c0f8d39dd09dcec72ce77c8fa1e138fd1b9f6137be58547c041050199e45bb09e171f1fa050b007a77e50590b6837211e0fada3217c950482c60a3c6243fa64
+    storybook: ^8.5.2
+  checksum: 10c0/1fba13233483f6b5b6115dac98a73a26b3a4ec7bd1f13764c837608067845da5d5e26b9a73f6430dbae559cefb1379f768e24a8384c0d2cbb3ad35ce21cf7567
   languageName: node
   linkType: hard
 
-"@storybook/addon-outline@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-outline@npm:8.5.1"
+"@storybook/addon-outline@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-outline@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/546d387e8175bfc55bf9ac47fc8bf0ce0a190ce43b2cf2a9b90ebd21be22875e92c3f5e1211caae4874a8c88494f7206aae895761c4abf7482e9668ba55d2142
+    storybook: ^8.5.2
+  checksum: 10c0/300fbc0e254069bf6c3e14eb8c3ffbab069db29c82e3f0135173d8d9e96e7d89187a3577de131b36b44c5201fa2d7dc3fd5083e814e0cec6dee7f5b6d34233e7
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-toolbars@npm:8.5.1"
+"@storybook/addon-toolbars@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-toolbars@npm:8.5.2"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/a49471696d6801343b2d369d536a7f03e968e22aedf2ac72ab50a3591e453729fbf5a16b57b7340e825f270acff34627e4b32797a7d651900ba60e80a3c04874
+    storybook: ^8.5.2
+  checksum: 10c0/7745e45026146f667a8f4c2540f3c5817a71b4e0f5ab6602d5f86c99da70c7ccd20e905445946041e0f46295b2eb27284a9b326a9ca916768cc06f01faf86899
   languageName: node
   linkType: hard
 
-"@storybook/addon-viewport@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/addon-viewport@npm:8.5.1"
+"@storybook/addon-viewport@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/addon-viewport@npm:8.5.2"
   dependencies:
     memoizerific: "npm:^1.11.3"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/ebe4f91d816dec3349a552bf3513e1d9049735d7ad6f34bb9a26265cafe5ae085f9d89db6820920a42e47e4be96d2b763339c7f0a49e6e62a8d83f85911f9b74
+    storybook: ^8.5.2
+  checksum: 10c0/8755d489e11fa376c6befe3383d9169f7727a0fa83da8c56ff9ceceb4a26dfb64f521e0656c4412fa26ec7aad3ede42347afa4940c3041a7c749f05eca888aec
   languageName: node
   linkType: hard
 
-"@storybook/blocks@npm:8.5.1, @storybook/blocks@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/blocks@npm:8.5.1"
+"@storybook/blocks@npm:8.5.2, @storybook/blocks@npm:^8.2.9":
+  version: 8.5.2
+  resolution: "@storybook/blocks@npm:8.5.2"
   dependencies:
     "@storybook/csf": "npm:0.1.12"
     "@storybook/icons": "npm:^1.2.12"
@@ -2424,42 +2450,42 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.5.1
+    storybook: ^8.5.2
   peerDependenciesMeta:
     react:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/670e97a7e0a27ae7fb890fc684797691a0443d191312d8231b28bad24009b8f418ea6a2b02c56add4c0090d0e388fd2b2081dd2fbf6b9fc66f1bda54497ea130
+  checksum: 10c0/a8345cdd2805aeaf1c6798ed91f34aa4b9edfcd25f55cbb0dd2bf027a30b23b9ee10f9e199d3022760df7b9d78357b7a2d3ed2f587e8bfa9aa456e5a77960926
   languageName: node
   linkType: hard
 
-"@storybook/builder-vite@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/builder-vite@npm:8.5.1"
+"@storybook/builder-vite@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/builder-vite@npm:8.5.2"
   dependencies:
-    "@storybook/csf-plugin": "npm:8.5.1"
+    "@storybook/csf-plugin": "npm:8.5.2"
     browser-assert: "npm:^1.2.1"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.5.1
+    storybook: ^8.5.2
     vite: ^4.0.0 || ^5.0.0 || ^6.0.0
-  checksum: 10c0/c8d1626f4a13141d1c4422a9ac4c0b2d3c8a8af82fe7c9212ea803a3ce157e4b6d6565194397088d352a42d5f05af047755f7224fd83424606f7005c8efe2ee9
+  checksum: 10c0/fe53f3b4463e6a3d35f08e63a16e1f65b9f178bf3d2ff776b4be5c82e31ac0e874cb599ed8659a829952deca5fbf5cc0b804b0b29a1a80234741dee8ba515684
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/components@npm:8.5.1"
+"@storybook/components@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/components@npm:8.5.2"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/1fd89b03dafb9e845478ea4a8eda750ca41cf6b2d95cfe4a62617d9f6e06ce2f01bd4728f75c8433dbbacc0692d56027bb278e678cf1c8205c48a128799aa92e
+  checksum: 10c0/a5eef011332c6a2f22a2efc91d82b577e9d6cdfe657cb9056c59050c8cfd1ad7999e237d408e403c33220b9849ec1f25c32dd2af0099d3a712e8b582409cad23
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/core@npm:8.5.1"
+"@storybook/core@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/core@npm:8.5.2"
   dependencies:
     "@storybook/csf": "npm:0.1.12"
     better-opn: "npm:^3.0.2"
@@ -2477,18 +2503,18 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 10c0/3838b1ce36331927f10c9c11210956752b00c05aa42de77b5551b82273c25d3ae1b7465f50b0c6757e9eb87dfe47bc7aa293225a038328e313e7b2f5a28f768a
+  checksum: 10c0/30716091ea9dd6e05ab079c67907f442c112cb6cb118d8a44e2be26f62398005f68dbdfbcb75a44bb2e59f468889e06dd92778de393550bf6fbb026c1c17e4ec
   languageName: node
   linkType: hard
 
-"@storybook/csf-plugin@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/csf-plugin@npm:8.5.1"
+"@storybook/csf-plugin@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/csf-plugin@npm:8.5.2"
   dependencies:
     unplugin: "npm:^1.3.1"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/c3fd9ea2bd1f0762f62926c79ce8677e1105ee86b53f472813f430bc682146d6e8e1ad692a53b88481315ba0ad9f46f3f14deea585721ad4933f87cb32dee0d8
+    storybook: ^8.5.2
+  checksum: 10c0/fb1fa5ddf821fbfc98387b58e5fa7847b6b2fff9014f49b352c4b60a4601229b1f087a87fa94bb0663189e5e57ec462264b22b8f147cfe80533d132994c550c6
   languageName: node
   linkType: hard
 
@@ -2527,122 +2553,122 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/instrumenter@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/instrumenter@npm:8.5.1"
+"@storybook/instrumenter@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/instrumenter@npm:8.5.2"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     "@vitest/utils": "npm:^2.1.1"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/513956e116c60fc20da6cd56823ef8ba46e5ab79bf134d3ec9de34a89547e5e0fd723fe6cc8e44984601786d5b1b75c190d68b51aa95f18e5cad5dd5bcb18e35
+    storybook: ^8.5.2
+  checksum: 10c0/76c54c17808a1f9e621af6d54a4b60c5c4216eb892908c0015f84291ae38743dfc054a263cd2a2ca6cb2eb066c26e4da28e0e739d737d7f573811848f4b367e9
   languageName: node
   linkType: hard
 
-"@storybook/manager-api@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/manager-api@npm:8.5.1"
+"@storybook/manager-api@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/manager-api@npm:8.5.2"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/5c5d3afc65081ddaa065b299f897d79df3e1d2779b110fd6d104fadfcdf0208d6ad0b7e7537b4a3db0e6f4f3fdea60a8ef52f6f61a05cc5b19ecc0ed0bb0c974
+  checksum: 10c0/4a41d4340db231b1598068002c1059993cc88c69bea62bef4f4be5b814d513109638b1692225e99689d94b98eb3ae31acfa8572fca3d5f4608151f86fc98d4a3
   languageName: node
   linkType: hard
 
-"@storybook/preview-api@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/preview-api@npm:8.5.1"
+"@storybook/preview-api@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/preview-api@npm:8.5.2"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/48f60644ac4fb748e2268470fd159768b5d3782ea6a11e4ad8631caf8207c614a8c05bb16f5404e9404786475b8e4b4eae2d168cbef103d9cb7dc023cc9ec196
+  checksum: 10c0/19010580a927a842c89eff7e1e31c4caea42fd1bb994fe10cc163c900e2dc1288152ffb6658432deb120a85bf8a97bb092c408dbd5fbf287960390defb968e2e
   languageName: node
   linkType: hard
 
-"@storybook/react-dom-shim@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/react-dom-shim@npm:8.5.1"
+"@storybook/react-dom-shim@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/react-dom-shim@npm:8.5.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.5.1
-  checksum: 10c0/13e6acf25d10f03396dbe0e1dc70e67e6c6c9a33217b8b9f8612bef9d77f34a5b2895a21fa9ef27d6022530056186b04f53123610c45e0fce88cdddc0b243b11
+    storybook: ^8.5.2
+  checksum: 10c0/6091c1dd4c5664963674aa5b96030256adf88c9a37b78a192363be975f09ac3f59b0562fcb89683266a28552a35dd3c87b329a333f45eb74a1014aa3f0115c53
   languageName: node
   linkType: hard
 
 "@storybook/react-vite@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/react-vite@npm:8.5.1"
+  version: 8.5.2
+  resolution: "@storybook/react-vite@npm:8.5.2"
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
     "@rollup/pluginutils": "npm:^5.0.2"
-    "@storybook/builder-vite": "npm:8.5.1"
-    "@storybook/react": "npm:8.5.1"
+    "@storybook/builder-vite": "npm:8.5.2"
+    "@storybook/react": "npm:8.5.2"
     find-up: "npm:^5.0.0"
     magic-string: "npm:^0.30.0"
     react-docgen: "npm:^7.0.0"
     resolve: "npm:^1.22.8"
     tsconfig-paths: "npm:^4.2.0"
   peerDependencies:
-    "@storybook/test": 8.5.1
+    "@storybook/test": 8.5.2
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.5.1
+    storybook: ^8.5.2
     vite: ^4.0.0 || ^5.0.0 || ^6.0.0
   peerDependenciesMeta:
     "@storybook/test":
       optional: true
-  checksum: 10c0/c88740fedbe127fba659c56eaa6f6f49f52720f0b7b22c2b304ca44c54be874941bdb3dfaac96537a6d8c9992c1375c341e21287057e139b985055ab46fa88b9
+  checksum: 10c0/3e3cd59022acb9a08dd086f6b5a219b09c43951a4b1b61efa05568aaa3b91450f70b30ad1cd23c79454996446f39322dc5ede6cab462b400e92f035f2fbdba71
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:8.5.1, @storybook/react@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/react@npm:8.5.1"
+"@storybook/react@npm:8.5.2, @storybook/react@npm:^8.2.9":
+  version: 8.5.2
+  resolution: "@storybook/react@npm:8.5.2"
   dependencies:
-    "@storybook/components": "npm:8.5.1"
+    "@storybook/components": "npm:8.5.2"
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/manager-api": "npm:8.5.1"
-    "@storybook/preview-api": "npm:8.5.1"
-    "@storybook/react-dom-shim": "npm:8.5.1"
-    "@storybook/theming": "npm:8.5.1"
+    "@storybook/manager-api": "npm:8.5.2"
+    "@storybook/preview-api": "npm:8.5.2"
+    "@storybook/react-dom-shim": "npm:8.5.2"
+    "@storybook/theming": "npm:8.5.2"
   peerDependencies:
-    "@storybook/test": 8.5.1
+    "@storybook/test": 8.5.2
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.5.1
+    storybook: ^8.5.2
     typescript: ">= 4.2.x"
   peerDependenciesMeta:
     "@storybook/test":
       optional: true
     typescript:
       optional: true
-  checksum: 10c0/c873bf77740cf1603e8b749da2e9df65413a1b62cd80a6b5d9f22caf6576e17610f5ea31963a18ebf54878a5063540e3b3124de37965084e5270fefac90a800a
+  checksum: 10c0/f8e8c276c22531a59703c26aa9f58a7827110448f8610942fe1ee2f4413eaecde3d6473caaf4195d6ec90164e9851f1871673e41d512c0bcb07d9571eb06a9f2
   languageName: node
   linkType: hard
 
-"@storybook/test@npm:8.5.1, @storybook/test@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "@storybook/test@npm:8.5.1"
+"@storybook/test@npm:8.5.2, @storybook/test@npm:^8.2.9":
+  version: 8.5.2
+  resolution: "@storybook/test@npm:8.5.2"
   dependencies:
     "@storybook/csf": "npm:0.1.12"
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/instrumenter": "npm:8.5.1"
+    "@storybook/instrumenter": "npm:8.5.2"
     "@testing-library/dom": "npm:10.4.0"
     "@testing-library/jest-dom": "npm:6.5.0"
     "@testing-library/user-event": "npm:14.5.2"
     "@vitest/expect": "npm:2.0.5"
     "@vitest/spy": "npm:2.0.5"
   peerDependencies:
-    storybook: ^8.5.1
-  checksum: 10c0/dca5531a036febf30aafc4568d9453734cec3b6e2c78ed11f96b34accc8c648631de0164d02a5cb4de08d8c0409df8450c1ccbf37b9684e62052ddb8bc3bfa8c
+    storybook: ^8.5.2
+  checksum: 10c0/3fbb5ae9a68ee29d0b525ff1692f933909d5b20e8ecd4dcc429d503af406e4d325f4365aa10d346a2ec83478e1c824558ab88c31335b1f9f1ded7089cbc78682
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@storybook/theming@npm:8.5.1"
+"@storybook/theming@npm:8.5.2":
+  version: 8.5.2
+  resolution: "@storybook/theming@npm:8.5.2"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/808323c8b27c73dbbbf097740695f8fb0d10714daca55ec63454b234580b326403fe73ff01c36f7b23d78b815f9a9f77979563ba0ee169cdff7d2794c23bfbfd
+  checksum: 10c0/5e53775f5df8901826e0c8826939ba99e660e967e17c8cdb9089b21431c4eaedf29651ae0eedccc853717ec03b7e0b1769c28a96e3dea4d90115939073cfa352
   languageName: node
   linkType: hard
 
@@ -4358,6 +4384,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:9.3.0":
+  version: 9.3.0
+  resolution: "builder-util-runtime@npm:9.3.0"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10c0/191ed2bd5d721b54f68415af587477b5ecc25097af09489b1fa6e7e52cbebf24e7676817a75798778a2193154fb1392c87c1c650ab6c822ca4404a7d88033b2f
+  languageName: node
+  linkType: hard
+
 "builder-util@npm:26.0.0-alpha.3":
   version: 26.0.0-alpha.3
   resolution: "builder-util@npm:26.0.0-alpha.3"
@@ -5517,10 +5553,10 @@ __metadata:
   linkType: hard
 
 "electron-updater@npm:^6.1.7":
-  version: 6.3.9
-  resolution: "electron-updater@npm:6.3.9"
+  version: 6.4.0
+  resolution: "electron-updater@npm:6.4.0"
   dependencies:
-    builder-util-runtime: "npm:9.2.10"
+    builder-util-runtime: "npm:9.3.0"
     fs-extra: "npm:^10.1.0"
     js-yaml: "npm:^4.1.0"
     lazy-val: "npm:^1.0.5"
@@ -5528,7 +5564,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.6.3"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10c0/e692e8d744ba311caf17bfdf59d469b3f331b8dcbb174786ed69bba52b630093e8cd7d48f04c10e28cd25ead9c0896d42c92a25525275daaf47681da0dfd2094
+  checksum: 10c0/e530b344a9ce51ef58def6ffe4f8947e4c78504ae1580420ce51e54a7d7187430e0e5f2619049ee24d2fecd8f494b771ff40f886309bed9e7005df9dd6f9b153
   languageName: node
   linkType: hard
 
@@ -11554,10 +11590,10 @@ __metadata:
   linkType: hard
 
 "storybook@npm:^8.2.9":
-  version: 8.5.1
-  resolution: "storybook@npm:8.5.1"
+  version: 8.5.2
+  resolution: "storybook@npm:8.5.2"
   dependencies:
-    "@storybook/core": "npm:8.5.1"
+    "@storybook/core": "npm:8.5.2"
   peerDependencies:
     prettier: ^2 || ^3
   peerDependenciesMeta:
@@ -11567,7 +11603,7 @@ __metadata:
     getstorybook: ./bin/index.cjs
     sb: ./bin/index.cjs
     storybook: ./bin/index.cjs
-  checksum: 10c0/71519063fc9f97e55108f1917f722a23188aef105b1841ecdc240a52577cef68208c6b806185c4747c6cc183ad848cef05813d306399b37ee82536b78128bd3a
+  checksum: 10c0/8c6f4bf5782c695fa3a66ebceb0092e04476ecc4c4b681889db9a9875c19e561dcf1b0c68215df1734dff9706b0bb942a5c47426e5825611856b2da37b9bcf0d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hedron/engine@workspace:packages/engine"
   dependencies:
+    "@hedron/midi": "npm:^1.0.0-alpha.0"
     "@types/lodash.debounce": "npm:^4.0.9"
     lodash.debounce: "npm:^4.0.8"
     tsup: "npm:^8.3.5"


### PR DESCRIPTION
It's pretty clunky, and not very pretty, but a first pass at getting midi/midi learn working.

Confirmed to work with ccs, probably works with buttons

Went in with generic events in mind, figure most things could go through the same functions.

It's not at all set up for it, since midi is treated with quite a bit of privilege here, but still percolating on sketches-as-plugins idea, inputs coming from sketches, would need a good bit of architecture to say enable midi to have a midi learn popup where-as other inputs might need their own special thing, lfos with their additional per-param settings, etc. Don't think it needs to be solved at the moment, just sleepy spouting thought-trains choo-choo


Edit: Forgot about midival while writing this, could look into moving the code over in the future, it didn't take much code to get this working with vanilla js though. 

Also built off the clock branch so targeting that, if that branch is unlikely to merge soon, I can cherry pick the commits while targeting alpha