### PR TITLE
WIP Video Render

### DIFF
--- a/EXPERIMENTAL_FEATURES.md
+++ b/EXPERIMENTAL_FEATURES.md
@@ -1,0 +1,21 @@
+# Experimental Features in Hedron
+
+This document lists and describes experimental features available in Hedron. These features can be accessed via the developer console (f12).
+
+## Rendering
+
+### Saving an image
+`saveFrame()` - Save a timestamped image.
+
+### Saving an image sequence
+`renderFrames(count: number, name: string, ffmpeg?: boolean)` - Save a series of images.
+Images will be saved to the Documents folder, in a folder named name. It will overwrite any existing files. Each frame will be suffixed with its index. If `ffmpeg` is true, it will try to create a video using ffmpeg (must be installed and made accessible via the command line by the user).  
+ffmpeg command as follows:
+`ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
+
+### Testing a video loop
+`resetEvery(seconds: number, jumpTo?: number)` - Loop after a given time
+`cancelReset()` - Stop the looping
+`jumpTo` is used to test the 'loop point' of a video, it will jump to the end, play through to the loop + the opposite of the jump time.
+ie; `resetEvery(6, 5)` will play from seconds 5-6, then 6-1, then back to 5.
+The way the video loops work is by passing large/negative `deltaTime` values to the sketches. `deltaTime` is a new top-level property that was added to the object passed on sketch `update`

--- a/EXPERIMENTAL_FEATURES.md
+++ b/EXPERIMENTAL_FEATURES.md
@@ -8,14 +8,21 @@ This document lists and describes experimental features available in Hedron. The
 `saveFrame()` - Save a timestamped image.
 
 ### Saving an image sequence
-`renderFrames(count: number, name: string, ffmpeg?: boolean)` - Save a series of images.
-Images will be saved to the Documents folder, in a folder named name. It will overwrite any existing files. Each frame will be suffixed with its index. If `ffmpeg` is true, it will try to create a video using ffmpeg (must be installed and made accessible via the command line by the user).  
-ffmpeg command as follows:
-`ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
+- `renderFrames(count: number, name: string, ffmpeg?: boolean)`
+  - Save a series of images.
+  - Images will be saved to the Documents folder, in a folder named `name`.
+  - Existing files will be overwritten.
+  - Each frame will be suffixed with its index.
+  - If `ffmpeg` is true, it will try to create a video using ffmpeg (must be installed and made accessible via the command line by the user).
+  - ffmpeg command: `ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
 
 ### Testing a video loop
-`resetEvery(seconds: number, jumpTo?: number)` - Loop after a given time
-`cancelReset()` - Stop the looping
-`jumpTo` is used to test the 'loop point' of a video, it will jump to the end, play through to the loop + the opposite of the jump time.
-ie; `resetEvery(6, 5)` will play from seconds 5-6, then 6-1, then back to 5.
-The way the video loops work is by passing large/negative `deltaTime` values to the sketches. `deltaTime` is a new top-level property that was added to the object passed on sketch `update`
+- `resetEvery(seconds: number, jumpTo?: number)`
+  - Loop after a given time
+  - `jumpTo` is used to test the 'loop point' of a video.
+  - It will jump to the end, play through to the loop + the opposite of the jump time.
+  - ie; `resetEvery(6, 5)` will play from seconds 5-6, then 6-1, then back to 5.
+  - The way the video loops work is by passing large/negative `deltaTime` values to the sketches.
+  - `deltaTime` is a new top-level property that was added to the object passed on sketch `update`.
+- `cancelReset()`
+  -  Stop the looping.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ If you're just working on the clock package, use `yarn dev:clock`. This will bui
 ## Update Hedron version
 
 Run `npx lerna version`. This bumps all versions across packages. While in alpha, we want to choose the "Custom Prerelease" option. This will keep the format of `1.0.0-alpha.x`, where only `x` gets bumped (as major/minor/patch makes no sense).
+
+# Experimental Features
+
+Access [Experimental Features](./EXPERIMENTAL_FEATURES.md) via the command line, these are features created during show prep, and are not yet complete in terms of funcationality/UI.

--- a/packages/desktop/src/main/SketchesServer.ts
+++ b/packages/desktop/src/main/SketchesServer.ts
@@ -85,6 +85,8 @@ export class SketchesServer extends EventEmitter {
         // text: loaded into sketch as string
         '.glsl': 'text',
         '.isf': 'text',
+        '.frag': 'text',
+        '.vert': 'text',
       },
       assetNames: '[dir]/[name]-[hash]',
       publicPath: `http://${HOST}:${port}`,

--- a/packages/desktop/src/main/handlers/frameHandlers.ts
+++ b/packages/desktop/src/main/handlers/frameHandlers.ts
@@ -1,0 +1,89 @@
+import path from 'path'
+import fs, { mkdirSync, existsSync } from 'fs'
+import { exec } from 'child_process'
+import { app } from 'electron'
+import { SaveFrameResponse } from '@shared/FrameEvents'
+
+function ensureDir(dirPath: string) {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath)
+  }
+}
+
+function getDocumentsPath() {
+  return app.getPath('documents')
+}
+
+function getFrameDirPath(name: string) {
+  const dirPath = path.join(getDocumentsPath(), name)
+  ensureDir(dirPath)
+  return dirPath
+}
+
+function getFrameFilePath(name: string, frameIndex: number) {
+  return path.join(getFrameDirPath(name), `${name}-${frameIndex}.png`)
+}
+
+function getTimestampedFilePath() {
+  const documentsPath = getDocumentsPath()
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const filename = `hedron-${timestamp}.png`
+  return path.join(documentsPath, filename)
+}
+
+export async function saveFrameHandler(
+  _: unknown,
+  base64Data: string,
+  name?: string,
+  frameIndex?: number,
+): Promise<SaveFrameResponse> {
+  try {
+    let filePath: string
+    if (name !== undefined && frameIndex !== undefined) {
+      filePath = getFrameFilePath(name, frameIndex)
+    } else {
+      filePath = getTimestampedFilePath()
+    }
+    fs.writeFileSync(filePath, base64Data, 'base64')
+    return { success: true, path: filePath }
+  } catch (error) {
+    console.error('Error saving frame:', error)
+    return { success: false, error: String(error) }
+  }
+}
+
+export async function saveFrameSequenceHandler(
+  _: unknown,
+  base64Array: string[],
+  name: string,
+  video: boolean = false,
+) {
+  try {
+    const dirPath = getFrameDirPath(name)
+    if (base64Array && base64Array.length > 0) {
+      for (let i = 0; i < base64Array.length; i++) {
+        const filePath = path.join(dirPath, `${name}-${i}.png`)
+        fs.writeFileSync(filePath, base64Array[i], 'base64')
+      }
+    }
+    let videoPath: string | undefined = undefined
+    if (video) {
+      videoPath = path.join(dirPath, `${name}.mp4`)
+      const ffmpegCmd = `ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
+      await new Promise<void>((resolve, reject) => {
+        exec(ffmpegCmd, (error, _stdout, stderr) => {
+          if (error) {
+            console.error('ffmpeg error:', error, stderr)
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
+      })
+    }
+    return { success: true, path: dirPath, videoPath }
+  } catch (error) {
+    console.error('Error saving frame sequence:', error)
+    return { success: false, error: String(error) }
+  }
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -115,23 +115,33 @@ ipcMain.handle(SketchEvents.StartSketchesServer, async (_, sketchesDir: string) 
 })
 
 // Simple handler for saving frames as PNG files
-ipcMain.handle(FrameEvents.SaveFrame, async (_, base64Data: string): Promise<SaveFrameResponse> => {
-  try {
-    // Save to user's documents folder
-    const documentsPath = app.getPath('documents')
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    const filename = `hedron-${timestamp}.png`
-    const filePath = path.join(documentsPath, filename)
-    // Write the file
-    fs.writeFileSync(filePath, base64Data, 'base64')
-    return { success: true, path: filePath }
-  } catch (error) {
-    console.error('Error saving frame:', error)
-    return { success: false, error: String(error) }
-  }
-})
+ipcMain.handle(
+  FrameEvents.SaveFrame,
+  async (_, base64Data: string, name?: string, frameIndex?: number): Promise<SaveFrameResponse> => {
+    try {
+      const documentsPath = app.getPath('documents')
+      let filePath: string
+      if (name !== undefined && frameIndex !== undefined) {
+        const dirPath = path.join(documentsPath, name)
+        if (!existsSync(dirPath)) {
+          mkdirSync(dirPath)
+        }
+        filePath = path.join(dirPath, `${name}-${frameIndex}.png`)
+      } else {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+        const filename = `hedron-${timestamp}.png`
+        filePath = path.join(documentsPath, filename)
+      }
+      fs.writeFileSync(filePath, base64Data, 'base64')
+      return { success: true, path: filePath }
+    } catch (error) {
+      console.error('Error saving frame:', error)
+      return { success: false, error: String(error) }
+    }
+  },
+)
 
-// Handler for saving a sequence of frames
+// Handler for saving a sequence of frames or just creating a video
 ipcMain.handle(
   FrameEvents.SaveFrameSequence,
   async (_, base64Array: string[], name: string, video: boolean = false) => {
@@ -141,21 +151,17 @@ ipcMain.handle(
       if (!existsSync(dirPath)) {
         mkdirSync(dirPath)
       }
-      for (let i = 0; i < base64Array.length; i++) {
-        const filename = `${name}-${i}.png`
-        const filePath = path.join(dirPath, filename)
-        fs.writeFileSync(filePath, base64Array[i], 'base64')
+      // Only write images if base64Array is provided and not empty
+      if (base64Array && base64Array.length > 0) {
+        for (let i = 0; i < base64Array.length; i++) {
+          const filename = `${name}-${i}.png`
+          const filePath = path.join(dirPath, filename)
+          fs.writeFileSync(filePath, base64Array[i], 'base64')
+        }
       }
 
       let videoPath: string | undefined = undefined
       if (video) {
-        // ffmpeg command to convert PNG sequence to mp4
-        // -r 30: 30 fps, adjust as needed
-        // -y: overwrite output file if exists
-        // -framerate 30: input framerate
-        // -i: input pattern
-        // -pix_fmt yuv420p: for compatibility
-        // -crf 18: high quality
         videoPath = path.join(dirPath, `${name}.mp4`)
         const ffmpegCmd = `ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
         await new Promise<void>((resolve, reject) => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+import fs from 'fs'
 import { app, BrowserWindow, dialog, ipcMain, screen, session } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { REDUX_DEVTOOLS, installExtension } from '@tomjs/electron-devtools-installer'
@@ -9,13 +11,13 @@ import {
   SaveProjectResponse,
   SketchEvents,
 } from '@shared/Events'
+import { FrameEvents, SaveFrameResponse } from '@shared/FrameEvents'
 import { updateDisplayMenu, updateMenu } from '@main/menu'
 import { createWindow } from '@main/mainWindow'
 import { startSketchesServer } from '@main/handleSketchFiles'
 import { devSettings } from '@main/devSettings'
 import { saveProjectFile } from '@main/handlers/saveProjectFile'
 import { openProjectFile } from '@main/handlers/openProjectFile'
-
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
 // This method will be called when Electron has finished
@@ -109,4 +111,21 @@ ipcMain.handle(
 
 ipcMain.handle(SketchEvents.StartSketchesServer, async (_, sketchesDir: string) => {
   return await startSketchesServer(sketchesDir)
+})
+
+// Simple handler for saving frames as PNG files
+ipcMain.handle(FrameEvents.SaveFrame, async (_, base64Data: string): Promise<SaveFrameResponse> => {
+  try {
+    // Save to user's documents folder
+    const documentsPath = app.getPath('documents')
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const filename = `hedron-${timestamp}.png`
+    const filePath = path.join(documentsPath, filename)
+    // Write the file
+    fs.writeFileSync(filePath, base64Data, 'base64')
+    return { success: true, path: filePath }
+  } catch (error) {
+    console.error('Error saving frame:', error)
+    return { success: false, error: String(error) }
+  }
 })

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
-import fs from 'fs'
+import fs, { mkdirSync, existsSync } from 'fs'
+import { exec } from 'child_process'
 import { app, BrowserWindow, dialog, ipcMain, screen, session } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { REDUX_DEVTOOLS, installExtension } from '@tomjs/electron-devtools-installer'
@@ -129,3 +130,50 @@ ipcMain.handle(FrameEvents.SaveFrame, async (_, base64Data: string): Promise<Sav
     return { success: false, error: String(error) }
   }
 })
+
+// Handler for saving a sequence of frames
+ipcMain.handle(
+  FrameEvents.SaveFrameSequence,
+  async (_, base64Array: string[], name: string, video: boolean = false) => {
+    try {
+      const documentsPath = app.getPath('documents')
+      const dirPath = path.join(documentsPath, name)
+      if (!existsSync(dirPath)) {
+        mkdirSync(dirPath)
+      }
+      for (let i = 0; i < base64Array.length; i++) {
+        const filename = `${name}-${i}.png`
+        const filePath = path.join(dirPath, filename)
+        fs.writeFileSync(filePath, base64Array[i], 'base64')
+      }
+
+      let videoPath: string | undefined = undefined
+      if (video) {
+        // ffmpeg command to convert PNG sequence to mp4
+        // -r 30: 30 fps, adjust as needed
+        // -y: overwrite output file if exists
+        // -framerate 30: input framerate
+        // -i: input pattern
+        // -pix_fmt yuv420p: for compatibility
+        // -crf 18: high quality
+        videoPath = path.join(dirPath, `${name}.mp4`)
+        const ffmpegCmd = `ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
+        await new Promise<void>((resolve, reject) => {
+          exec(ffmpegCmd, (error, stdout, stderr) => {
+            if (error) {
+              console.error('ffmpeg error:', error, stderr)
+              reject(error)
+            } else {
+              resolve()
+            }
+          })
+        })
+      }
+
+      return { success: true, path: dirPath, videoPath }
+    } catch (error) {
+      console.error('Error saving frame sequence:', error)
+      return { success: false, error: String(error) }
+    }
+  },
+)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,9 +1,7 @@
-import path from 'path'
-import fs, { mkdirSync, existsSync } from 'fs'
-import { exec } from 'child_process'
 import { app, BrowserWindow, dialog, ipcMain, screen, session } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { REDUX_DEVTOOLS, installExtension } from '@tomjs/electron-devtools-installer'
+import { saveFrameHandler, saveFrameSequenceHandler } from './handlers/frameHandlers'
 import { ProjectData } from '@shared/types'
 import {
   DialogEvents,
@@ -12,7 +10,7 @@ import {
   SaveProjectResponse,
   SketchEvents,
 } from '@shared/Events'
-import { FrameEvents, SaveFrameResponse } from '@shared/FrameEvents'
+import { FrameEvents } from '@shared/FrameEvents'
 import { updateDisplayMenu, updateMenu } from '@main/menu'
 import { createWindow } from '@main/mainWindow'
 import { startSketchesServer } from '@main/handleSketchFiles'
@@ -114,72 +112,6 @@ ipcMain.handle(SketchEvents.StartSketchesServer, async (_, sketchesDir: string) 
   return await startSketchesServer(sketchesDir)
 })
 
-// Simple handler for saving frames as PNG files
-ipcMain.handle(
-  FrameEvents.SaveFrame,
-  async (_, base64Data: string, name?: string, frameIndex?: number): Promise<SaveFrameResponse> => {
-    try {
-      const documentsPath = app.getPath('documents')
-      let filePath: string
-      if (name !== undefined && frameIndex !== undefined) {
-        const dirPath = path.join(documentsPath, name)
-        if (!existsSync(dirPath)) {
-          mkdirSync(dirPath)
-        }
-        filePath = path.join(dirPath, `${name}-${frameIndex}.png`)
-      } else {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-        const filename = `hedron-${timestamp}.png`
-        filePath = path.join(documentsPath, filename)
-      }
-      fs.writeFileSync(filePath, base64Data, 'base64')
-      return { success: true, path: filePath }
-    } catch (error) {
-      console.error('Error saving frame:', error)
-      return { success: false, error: String(error) }
-    }
-  },
-)
-
-// Handler for saving a sequence of frames or just creating a video
-ipcMain.handle(
-  FrameEvents.SaveFrameSequence,
-  async (_, base64Array: string[], name: string, video: boolean = false) => {
-    try {
-      const documentsPath = app.getPath('documents')
-      const dirPath = path.join(documentsPath, name)
-      if (!existsSync(dirPath)) {
-        mkdirSync(dirPath)
-      }
-      // Only write images if base64Array is provided and not empty
-      if (base64Array && base64Array.length > 0) {
-        for (let i = 0; i < base64Array.length; i++) {
-          const filename = `${name}-${i}.png`
-          const filePath = path.join(dirPath, filename)
-          fs.writeFileSync(filePath, base64Array[i], 'base64')
-        }
-      }
-
-      let videoPath: string | undefined = undefined
-      if (video) {
-        videoPath = path.join(dirPath, `${name}.mp4`)
-        const ffmpegCmd = `ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
-        await new Promise<void>((resolve, reject) => {
-          exec(ffmpegCmd, (error, stdout, stderr) => {
-            if (error) {
-              console.error('ffmpeg error:', error, stderr)
-              reject(error)
-            } else {
-              resolve()
-            }
-          })
-        })
-      }
-
-      return { success: true, path: dirPath, videoPath }
-    } catch (error) {
-      console.error('Error saving frame sequence:', error)
-      return { success: false, error: String(error) }
-    }
-  },
-)
+// Replace inline frame handling code with imports from handlers/frameHandlers
+ipcMain.handle(FrameEvents.SaveFrame, saveFrameHandler)
+ipcMain.handle(FrameEvents.SaveFrameSequence, saveFrameSequenceHandler)

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchModulesDialog.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchModulesDialog.tsx
@@ -69,7 +69,7 @@ export const SketchModulesDialog = ({ closeDialog }: GlobalDialogProps) => {
         <PanelHeader iconName="add_circle" buttonOnClick={closeDialog}>
           Add sketch to scene
         </PanelHeader>
-        <PanelBody>
+        <PanelBody scrollable={true}>
           <CardList>
             {sketchModules.map((item) => (
               <SketchCard key={item.moduleId} item={item} closeDialog={closeDialog} />

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -10,6 +10,7 @@ import { App } from '@components/App/App'
 import '@renderer/windows'
 import '@renderer/ipc/mainThreadListen'
 import '@renderer/engine'
+import '@renderer/utils/frameCapture'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -1,7 +1,7 @@
 // This file adds a simple utility to the window object for saving frames as PNG files
 
 import { engine } from '@renderer/engine'
-import { FrameEvents, SaveFrameResponse, SaveFrameSequenceResponse } from '@shared/FrameEvents'
+import { FrameEvents, SaveFrameResponse } from '@shared/FrameEvents'
 
 // Define the type for the window object extension
 declare global {
@@ -11,6 +11,21 @@ declare global {
     resetEvery: (seconds: number, offset?: number) => void
     cancelReset: () => void
   }
+}
+// Helper to save a frame (base64 or dataUrl) via IPC
+async function saveFrameViaIPC(
+  dataUrl: string,
+  name?: string,
+  frameIndex?: number,
+): Promise<SaveFrameResponse> {
+  const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
+  const result = (await window.electronApi.ipcRenderer.invoke(
+    FrameEvents.SaveFrame,
+    base64Data,
+    name,
+    frameIndex,
+  )) as SaveFrameResponse
+  return result
 }
 
 // Implement the save frame function
@@ -22,14 +37,7 @@ window.saveFrame = async () => {
     return
   }
 
-  // Remove data URL header
-  const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
-
-  // Use Electron's IPC to save the file in the main process
-  const result = (await window.electronApi.ipcRenderer.invoke(
-    FrameEvents.SaveFrame,
-    base64Data,
-  )) as SaveFrameResponse
+  const result = await saveFrameViaIPC(dataUrl)
 
   if (result.success) {
     console.log(`Frame saved successfully to: ${result.path}`)
@@ -49,14 +57,7 @@ window.renderFrames = async (frameCount: number, name: string, video: boolean = 
       frameCount,
       fps,
       async (dataUrl: string, frameIndex: number) => {
-        const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
-        // Save each frame immediately
-        const result = await window.electronApi.ipcRenderer.invoke(
-          FrameEvents.SaveFrame,
-          base64Data,
-          name,
-          frameIndex,
-        )
+        const result = await saveFrameViaIPC(dataUrl, name, frameIndex)
         if (result.success && result.path) {
           filePaths.push(result.path)
         } else {

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -38,48 +38,54 @@ window.saveFrame = async () => {
 
 // Implement the render frames function
 window.renderFrames = async (frameCount: number, name: string, video: boolean = false) => {
-  const base64Array: string[] = []
+  const fps = 30
+  const filePaths: string[] = []
 
-  // Helper to wait for next animation frame
-  const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
-
-  for (let i = 0; i < frameCount; i++) {
-    // Advance engine state
-    if (engine.stepFrame) {
-      engine.stepFrame()
-    } else if (engine.render) {
-      engine.render()
-    }
-
-    // Wait for the next animation frame to ensure rendering is complete
-    await nextFrame()
-
-    // Capture the frame after rendering
-    const dataUrl = engine.captureFrame()
-    if (!dataUrl) {
-      console.error(`Failed to capture frame at index ${i}`)
-      return
-    }
-    base64Array.push(dataUrl.replace(/^data:image\/png;base64,/, ''))
-    // Optionally, show progress
-    if (i % 10 === 0) {
-      console.log(`Captured frame ${i + 1} / ${frameCount}`)
-    }
-  }
-  const result = (await window.electronApi.ipcRenderer.invoke(
-    FrameEvents.SaveFrameSequence,
-    base64Array,
-    name,
-    video,
-  )) as SaveFrameSequenceResponse
-
-  if (result.success) {
-    console.log(`Frame sequence saved to: ${result.path}`)
-    if (video && result.videoPath) {
-      console.log(`Video created at: ${result.videoPath}`)
-    }
+  if (typeof engine.renderFramesSequence === 'function') {
+    await engine.renderFramesSequence(
+      frameCount,
+      fps,
+      async (dataUrl: string, frameIndex: number) => {
+        const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
+        // Save each frame immediately
+        const result = await window.electronApi.ipcRenderer.invoke(
+          FrameEvents.SaveFrame,
+          base64Data,
+          name,
+          frameIndex,
+        )
+        if (result.success && result.path) {
+          filePaths.push(result.path)
+        } else {
+          console.error(`Failed to save frame ${frameIndex}: ${result.error}`)
+        }
+        if ((frameIndex + 1) % 10 === 0 || frameIndex === frameCount - 1) {
+          console.log(`Saved frame ${frameIndex + 1} / ${frameCount}`)
+        }
+      },
+    )
   } else {
-    console.error(`Failed to save frame sequence: ${result.error}`)
+    console.error('engine.renderFramesSequence is not available')
+    return
+  }
+
+  console.log(`Frame sequence saved to Documents/${name}/`)
+
+  // After all frames, optionally create video
+  let videoPath: string | undefined = undefined
+  if (video) {
+    const result = await window.electronApi.ipcRenderer.invoke(
+      FrameEvents.SaveFrameSequence,
+      [], // No base64 array needed, just trigger video creation
+      name,
+      true,
+    )
+    if (result.success && result.videoPath) {
+      videoPath = result.videoPath
+      console.log(`Video created at: ${videoPath}`)
+    } else {
+      console.error(`Failed to create video: ${result.error}`)
+    }
   }
 }
 

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -1,0 +1,41 @@
+// This file adds a simple utility to the window object for saving frames as PNG files
+
+import { engine } from '@renderer/engine'
+import { FrameEvents, SaveFrameResponse } from '@shared/FrameEvents'
+
+// Define the type for the window object extension
+declare global {
+  interface Window {
+    saveFrame: () => Promise<void>
+  }
+}
+
+// Implement the save frame function
+window.saveFrame = async () => {
+  const dataUrl = engine.captureFrame()
+
+  if (!dataUrl) {
+    console.error('Failed to capture frame: No canvas data available')
+    return
+  }
+
+  // Remove data URL header
+  const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
+
+  // Use Electron's IPC to save the file in the main process
+  const result = (await window.electronApi.ipcRenderer.invoke(
+    FrameEvents.SaveFrame,
+    base64Data,
+  )) as SaveFrameResponse
+
+  if (result.success) {
+    console.log(`Frame saved successfully to: ${result.path}`)
+  } else {
+    console.error(`Failed to save frame: ${result.error}`)
+  }
+}
+
+// Add a log to indicate the function is available
+console.log(
+  '💡 Use window.saveFrame() to save the current frame as a PNG file to your Documents folder',
+)

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -8,6 +8,8 @@ declare global {
   interface Window {
     saveFrame: () => Promise<void>
     renderFrames: (frameCount: number, name: string, video?: boolean) => Promise<void>
+    resetEvery: (seconds: number, offset?: number) => void
+    cancelReset: () => void
   }
 }
 
@@ -40,6 +42,7 @@ window.saveFrame = async () => {
 window.renderFrames = async (frameCount: number, name: string, video: boolean = false) => {
   const fps = 30
   const filePaths: string[] = []
+  engine.resetTime() // Reset the engine time before starting
 
   if (typeof engine.renderFramesSequence === 'function') {
     await engine.renderFramesSequence(
@@ -86,6 +89,52 @@ window.renderFrames = async (frameCount: number, name: string, video: boolean = 
     } else {
       console.error(`Failed to create video: ${result.error}`)
     }
+  }
+}
+
+let resetTimeoutId: NodeJS.Timeout | null = null
+/**
+ * 'Reset' the sketch time every x seconds by applying an offset to the deltaTime pased into sketches.
+ * This is useful for testing looping animations.
+ * There is an optional parameter to set an offset, which is useful for testing just the loop point of a long animation.
+ * This function does not actually reset the time, it just applies an offset to the deltaTime passed into sketches.
+ * @param seconds The number of seconds to reset the time every
+ * @param offset An optional offset to apply to the deltaTime passed into sketches. This is useful for testing just the loop point of a long animation.
+ * @example
+ * window.resetEvery(10) // Resets the time every 10 seconds
+ * window.resetEvery(10, 9) // Resets the time every 10 seconds, but starts at 9 seconds, plays to 10 seconds, then plays from 0 to 1 seconds, before jumping back to 9 and starting again.
+ */
+window.resetEvery = (seconds: number, offset?: number) => {
+  if (resetTimeoutId) {
+    clearTimeout(resetTimeoutId)
+  }
+  engine.resetTime() // Ensure the engine time is reset before starting
+  let animTime = seconds
+  if (offset) {
+    engine.jumpTime(offset)
+    animTime -= offset
+  }
+  let side: boolean = true // Used to alternate the jump time
+  const jump = () => {
+    engine.resetTime() // Reset the engine time
+    if (offset && side) {
+      engine.jumpTime(offset) // Jump to the offset time
+    }
+    side = !side // Alternate the side for the next jump
+    resetTimeoutId = setTimeout(jump, animTime * 1000)
+  }
+  resetTimeoutId = setTimeout(jump, animTime * 1000)
+}
+
+/**
+ * Cancel the resetEvery function, stopping the time resets.
+ */
+window.cancelReset = () => {
+  if (resetTimeoutId) {
+    engine.resetTime() // Reset the engine time when cancelling
+    clearTimeout(resetTimeoutId)
+    resetTimeoutId = null
+    console.log('Time reset cancelled')
   }
 }
 

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -1,12 +1,13 @@
 // This file adds a simple utility to the window object for saving frames as PNG files
 
 import { engine } from '@renderer/engine'
-import { FrameEvents, SaveFrameResponse } from '@shared/FrameEvents'
+import { FrameEvents, SaveFrameResponse, SaveFrameSequenceResponse } from '@shared/FrameEvents'
 
 // Define the type for the window object extension
 declare global {
   interface Window {
     saveFrame: () => Promise<void>
+    renderFrames: (frameCount: number, name: string, video?: boolean) => Promise<void>
   }
 }
 
@@ -35,7 +36,57 @@ window.saveFrame = async () => {
   }
 }
 
+// Implement the render frames function
+window.renderFrames = async (frameCount: number, name: string, video: boolean = false) => {
+  const base64Array: string[] = []
+
+  // Helper to wait for next animation frame
+  const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+  for (let i = 0; i < frameCount; i++) {
+    // Advance engine state
+    if (engine.stepFrame) {
+      engine.stepFrame()
+    } else if (engine.render) {
+      engine.render()
+    }
+
+    // Wait for the next animation frame to ensure rendering is complete
+    await nextFrame()
+
+    // Capture the frame after rendering
+    const dataUrl = engine.captureFrame()
+    if (!dataUrl) {
+      console.error(`Failed to capture frame at index ${i}`)
+      return
+    }
+    base64Array.push(dataUrl.replace(/^data:image\/png;base64,/, ''))
+    // Optionally, show progress
+    if (i % 10 === 0) {
+      console.log(`Captured frame ${i + 1} / ${frameCount}`)
+    }
+  }
+  const result = (await window.electronApi.ipcRenderer.invoke(
+    FrameEvents.SaveFrameSequence,
+    base64Array,
+    name,
+    video,
+  )) as SaveFrameSequenceResponse
+
+  if (result.success) {
+    console.log(`Frame sequence saved to: ${result.path}`)
+    if (video && result.videoPath) {
+      console.log(`Video created at: ${result.videoPath}`)
+    }
+  } else {
+    console.error(`Failed to save frame sequence: ${result.error}`)
+  }
+}
+
 // Add a log to indicate the function is available
 console.log(
   '💡 Use window.saveFrame() to save the current frame as a PNG file to your Documents folder',
+)
+console.log(
+  '💡 Use window.renderFrames(frameCount, name, video?) to save a sequence of frames to Documents/<name>/<name>-<frameIndex>.png and optionally create an mp4',
 )

--- a/packages/desktop/src/shared/FrameEvents.ts
+++ b/packages/desktop/src/shared/FrameEvents.ts
@@ -1,10 +1,18 @@
 // Events for frame capture functionality
 export enum FrameEvents {
   SaveFrame = 'save-frame',
+  SaveFrameSequence = 'save-frame-sequence',
 }
 
 export interface SaveFrameResponse {
   success: boolean
   path?: string
+  error?: string
+}
+
+export interface SaveFrameSequenceResponse {
+  success: boolean
+  path?: string
+  videoPath?: string
   error?: string
 }

--- a/packages/desktop/src/shared/FrameEvents.ts
+++ b/packages/desktop/src/shared/FrameEvents.ts
@@ -1,0 +1,10 @@
+// Events for frame capture functionality
+export enum FrameEvents {
+  SaveFrame = 'save-frame',
+}
+
+export interface SaveFrameResponse {
+  success: boolean
+  path?: string
+  error?: string
+}

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -19,6 +19,8 @@ export class HedronEngine {
   public plugins: Record<string, IPlugin> = {}
   private onFrameStart?: () => void
   private onFrameEnd?: () => void
+  private running: boolean = false
+  private paused: boolean = false
 
   constructor(params?: { onFrameStart?: () => void; onFrameEnd?: () => void }) {
     this.store = createEngineStore()
@@ -118,10 +120,24 @@ export class HedronEngine {
   }
 
   run() {
+    if (this.running) return
+    this.running = true
+    this.paused = false
+
     const debugScene = createDebugScene(this.renderer)
+    let lastTime = performance.now()
 
     const loop = (): void => {
+      if (!this.running || this.paused) {
+        requestAnimationFrame(loop)
+        return
+      }
+
       this.onFrameStart?.()
+
+      const now = performance.now()
+      const deltaTime = (now - lastTime) / 1000
+      lastTime = now
 
       const state = this.store.getState()
       const sketchInstances = this.sketchManager!.getSketchInstances()
@@ -129,15 +145,13 @@ export class HedronEngine {
 
       Object.keys(state.sketches).forEach((sketchId) => {
         const paramValues = getSketchParamValues(state, sketchId)
-
         const instance = sketchInstances[sketchId]
-
         if (instance.getPasses) {
           instance.getPasses(debugScene).forEach((pass) => {
             debugScene.addPass(pass)
           })
         }
-        instance.update({ deltaFrame: 1, params: paramValues })
+        instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
       })
 
       requestAnimationFrame(loop)
@@ -149,5 +163,74 @@ export class HedronEngine {
     }
 
     loop()
+  }
+
+  public pause() {
+    this.paused = true
+  }
+
+  public resume() {
+    if (!this.running) {
+      this.run()
+    } else {
+      this.paused = false
+      this.run()
+    }
+  }
+
+  public stop() {
+    this.running = false
+    this.paused = false
+  }
+
+  /**
+   * Render a sequence of frames at a fixed framerate.
+   * Calls onFrame(dataUrl, frameIndex) after each frame.
+   * Does not accumulate any frame data in memory.
+   */
+  public async renderFramesSequence(
+    frameCount: number,
+    fps: number = 30,
+    onFrame: (dataUrl: string, frameIndex: number) => Promise<void> | void,
+  ): Promise<void> {
+    this.paused = true
+
+    const debugScene = createDebugScene(this.renderer)
+    const state = this.store.getState()
+    const sketchInstances = this.sketchManager!.getSketchInstances()
+    const frameDuration = 1 / fps
+
+    for (let i = 0; i < frameCount; i++) {
+      this.onFrameStart?.()
+
+      const deltaTime = frameDuration
+
+      debugScene.clearPasses()
+      Object.keys(state.sketches).forEach((sketchId) => {
+        const paramValues = getSketchParamValues(state, sketchId)
+        const instance = sketchInstances[sketchId]
+        if (instance.getPasses) {
+          instance.getPasses(debugScene).forEach((pass) => {
+            debugScene.addPass(pass)
+          })
+        }
+        instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
+      })
+
+      this.renderer.render(debugScene)
+      this.onFrameEnd?.()
+
+      const dataUrl = this.captureFrame()
+      if (!dataUrl) throw new Error(`Failed to capture frame at index ${i}`)
+
+      await onFrame(dataUrl, i)
+
+      // Simulate fixed framerate by waiting if needed
+      if (i < frameCount - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+      }
+    }
+
+    this.paused = false
   }
 }

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -22,6 +22,9 @@ export class HedronEngine {
   private running: boolean = false
   private paused: boolean = false
 
+  private extraTime: number = 0 // For time manipulation, e.g. for skipping frames
+  private totalTime: number = 0 // Total time for the engine, used for resetting time
+
   constructor(params?: { onFrameStart?: () => void; onFrameEnd?: () => void }) {
     this.store = createEngineStore()
     this.sketchManager = new SketchManager()
@@ -136,7 +139,12 @@ export class HedronEngine {
       this.onFrameStart?.()
 
       const now = performance.now()
-      const deltaTime = (now - lastTime) / 1000
+      let deltaTime = (now - lastTime) / 1000
+      if (this.extraTime != 0) {
+        deltaTime += this.extraTime
+        this.extraTime = 0
+      }
+      this.totalTime += deltaTime
       lastTime = now
 
       const state = this.store.getState()
@@ -203,7 +211,12 @@ export class HedronEngine {
     for (let i = 0; i < frameCount; i++) {
       this.onFrameStart?.()
 
-      const deltaTime = frameDuration
+      let deltaTime = frameDuration
+      if (this.extraTime != 0) {
+        deltaTime += this.extraTime
+        this.extraTime = 0
+      }
+      this.totalTime += deltaTime
 
       debugScene.clearPasses()
       Object.keys(state.sketches).forEach((sketchId) => {
@@ -232,5 +245,14 @@ export class HedronEngine {
     }
 
     this.paused = false
+  }
+
+  public jumpTime(seconds: number): void {
+    this.extraTime += seconds
+  }
+
+  public resetTime(): void {
+    this.extraTime -= this.totalTime
+    console.log(`Resetting time, extraTime: ${this.extraTime}, totalTime: ${this.totalTime}`)
   }
 }

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -105,6 +105,10 @@ export class HedronEngine {
     this.renderer.stopOutput()
   }
 
+  public captureFrame(): string | null {
+    return this.renderer.captureFrame()
+  }
+
   public getStore() {
     return this.store
   }

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -23,6 +23,7 @@ export class HedronEngine {
   private onFrameEnd?: () => void
   private running: boolean = false
   private paused: boolean = false
+  private scene: EngineScene // The main scene for rendering sketches
 
   private extraTime: number = 0 // For time manipulation, e.g. for skipping frames
   private totalTime: number = 0 // Total time for the engine, used for resetting time
@@ -31,6 +32,7 @@ export class HedronEngine {
     this.store = createEngineStore()
     this.sketchManager = new SketchManager()
     this.renderer = new Renderer()
+    this.scene = createDebugScene(this.renderer)
 
     this.onFrameStart = params?.onFrameStart
     this.onFrameEnd = params?.onFrameEnd
@@ -183,7 +185,6 @@ export class HedronEngine {
     this.running = true
     this.paused = false
 
-    const debugScene = createDebugScene(this.renderer)
     let lastTime = performance.now()
 
     const loop = (): void => {
@@ -207,7 +208,7 @@ export class HedronEngine {
       this.totalTime += deltaTime
       lastTime = now
 
-      this.advanceFrame(debugScene, deltaTime)
+      this.advanceFrame(this.scene, deltaTime)
 
       requestAnimationFrame(loop)
       this.onFrameEnd?.()
@@ -231,7 +232,6 @@ export class HedronEngine {
   ): Promise<void> {
     this.paused = true
 
-    const debugScene = createDebugScene(this.renderer)
     const frameDuration = 1 / fps
 
     for (let i = 0; i < frameCount; i++) {
@@ -244,7 +244,7 @@ export class HedronEngine {
       }
       this.totalTime += deltaTime
 
-      this.advanceFrame(debugScene, deltaTime)
+      this.advanceFrame(this.scene, deltaTime)
       this.onFrameEnd?.()
 
       const dataUrl = this.captureFrame()

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -1,3 +1,4 @@
+import { Pass } from 'postprocessing'
 import { listenToStore } from './storeListener'
 import { Result } from './types'
 import { importSketchModule } from './importSketchModule'
@@ -10,6 +11,7 @@ import { EngineData, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
 import { createEngineStore, EngineStore } from '@store/engineStore'
 import { getSketchParamValues } from '@store/selectors/getSketchParamValues'
+import { EngineScene } from '@world/EngineScene'
 
 export class HedronEngine {
   private renderer: Renderer
@@ -155,7 +157,7 @@ export class HedronEngine {
    * @param debugScene The debug scene object to update and render.
    * @param deltaTime The time delta (in seconds) to advance this frame.
    */
-  private advanceFrame(debugScene: any, deltaTime: number) {
+  private advanceFrame(debugScene: EngineScene, deltaTime: number) {
     const state = this.store.getState()
     const sketchInstances = this.sketchManager!.getSketchInstances()
     debugScene.clearPasses()
@@ -163,11 +165,11 @@ export class HedronEngine {
       const paramValues = getSketchParamValues(state, sketchId)
       const instance = sketchInstances[sketchId]
       if (instance.getPasses) {
-        instance.getPasses(debugScene).forEach((pass: any) => {
+        instance.getPasses(debugScene).forEach((pass: Pass) => {
           debugScene.addPass(pass)
         })
       }
-      instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
+      instance.update({ deltaFrame: 1, deltaTime, params: paramValues, scene: debugScene })
     })
     this.renderer.render(debugScene)
   }

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -122,7 +122,61 @@ export class HedronEngine {
     return stripForSave(this.store.getState())
   }
 
-  run() {
+  /**
+   * Pauses the engine's main render loop.
+   */
+  public pause() {
+    this.paused = true
+  }
+
+  /**
+   * Resumes the engine's main render loop. If the engine is not running, starts it.
+   */
+  public resume() {
+    if (!this.running) {
+      this.run()
+    } else {
+      this.paused = false
+      this.run()
+    }
+  }
+
+  /**
+   * Stops the engine's main render loop and resets running/paused state.
+   */
+  public stop() {
+    this.running = false
+    this.paused = false
+  }
+
+  /**
+   * Advances the engine state by one frame, updating all sketches and rendering the scene.
+   * Shared by both the real-time loop and fixed-framerate sequence rendering.
+   * @param debugScene The debug scene object to update and render.
+   * @param deltaTime The time delta (in seconds) to advance this frame.
+   */
+  private advanceFrame(debugScene: any, deltaTime: number) {
+    const state = this.store.getState()
+    const sketchInstances = this.sketchManager!.getSketchInstances()
+    debugScene.clearPasses()
+    Object.keys(state.sketches).forEach((sketchId) => {
+      const paramValues = getSketchParamValues(state, sketchId)
+      const instance = sketchInstances[sketchId]
+      if (instance.getPasses) {
+        instance.getPasses(debugScene).forEach((pass: any) => {
+          debugScene.addPass(pass)
+        })
+      }
+      instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
+    })
+    this.renderer.render(debugScene)
+  }
+
+  /**
+   * Starts the engine's main real-time render loop.
+   * This loop runs at the browser's refresh rate using requestAnimationFrame.
+   */
+  public run() {
     if (this.running) return
     this.running = true
     this.paused = false
@@ -131,7 +185,11 @@ export class HedronEngine {
     let lastTime = performance.now()
 
     const loop = (): void => {
-      if (!this.running || this.paused) {
+      if (!this.running) {
+        return
+      }
+
+      if (this.paused) {
         requestAnimationFrame(loop)
         return
       }
@@ -147,54 +205,22 @@ export class HedronEngine {
       this.totalTime += deltaTime
       lastTime = now
 
-      const state = this.store.getState()
-      const sketchInstances = this.sketchManager!.getSketchInstances()
-      debugScene.clearPasses()
-
-      Object.keys(state.sketches).forEach((sketchId) => {
-        const paramValues = getSketchParamValues(state, sketchId)
-        const instance = sketchInstances[sketchId]
-        if (instance.getPasses) {
-          instance.getPasses(debugScene).forEach((pass) => {
-            debugScene.addPass(pass)
-          })
-        }
-        instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
-      })
+      this.advanceFrame(debugScene, deltaTime)
 
       requestAnimationFrame(loop)
-      if (debugScene) {
-        this.renderer.render(debugScene)
-      }
-
       this.onFrameEnd?.()
     }
 
     loop()
   }
 
-  public pause() {
-    this.paused = true
-  }
-
-  public resume() {
-    if (!this.running) {
-      this.run()
-    } else {
-      this.paused = false
-      this.run()
-    }
-  }
-
-  public stop() {
-    this.running = false
-    this.paused = false
-  }
-
   /**
    * Render a sequence of frames at a fixed framerate.
    * Calls onFrame(dataUrl, frameIndex) after each frame.
    * Does not accumulate any frame data in memory.
+   * @param frameCount Number of frames to render
+   * @param fps Frames per second
+   * @param onFrame Callback invoked with the frame's data URL and index after each frame
    */
   public async renderFramesSequence(
     frameCount: number,
@@ -204,8 +230,6 @@ export class HedronEngine {
     this.paused = true
 
     const debugScene = createDebugScene(this.renderer)
-    const state = this.store.getState()
-    const sketchInstances = this.sketchManager!.getSketchInstances()
     const frameDuration = 1 / fps
 
     for (let i = 0; i < frameCount; i++) {
@@ -218,19 +242,7 @@ export class HedronEngine {
       }
       this.totalTime += deltaTime
 
-      debugScene.clearPasses()
-      Object.keys(state.sketches).forEach((sketchId) => {
-        const paramValues = getSketchParamValues(state, sketchId)
-        const instance = sketchInstances[sketchId]
-        if (instance.getPasses) {
-          instance.getPasses(debugScene).forEach((pass) => {
-            debugScene.addPass(pass)
-          })
-        }
-        instance.update({ deltaFrame: 1, deltaTime, params: paramValues })
-      })
-
-      this.renderer.render(debugScene)
+      this.advanceFrame(debugScene, deltaTime)
       this.onFrameEnd?.()
 
       const dataUrl = this.captureFrame()
@@ -247,10 +259,17 @@ export class HedronEngine {
     this.paused = false
   }
 
+  /**
+   * Adds or subtracts time from the engine's timeline, used for time manipulation.
+   * @param seconds Number of seconds to jump forward (positive) or backward (negative)
+   */
   public jumpTime(seconds: number): void {
     this.extraTime += seconds
   }
 
+  /**
+   * Resets the engine's timeline to zero.
+   */
   public resetTime(): void {
     this.extraTime -= this.totalTime
     console.log(`Resetting time, extraTime: ${this.extraTime}, totalTime: ${this.totalTime}`)

--- a/packages/engine/src/world/Renderer.ts
+++ b/packages/engine/src/world/Renderer.ts
@@ -15,6 +15,7 @@ export class Renderer {
   private canvas: HTMLCanvasElement | undefined
   private previewContext: CanvasRenderingContext2D | undefined | null
   public aspectRatio: number = 1
+  private isRendering: boolean = false
 
   private isSendingOutput = false
 
@@ -31,6 +32,7 @@ export class Renderer {
   public createCanvas(containerEl: HTMLDivElement): void {
     const renderer = new WebGLRenderer({
       antialias: false, // Antialiasing should be handled by the composer
+      preserveDrawingBuffer: true, // Required for frame capture to work consistently
     })
     this.composer = new EffectComposer(renderer)
 
@@ -40,6 +42,22 @@ export class Renderer {
     this.viewerContainer = containerEl
 
     this.setResizeObserver(containerEl)
+  }
+
+  // Capture the current frame as a data URL
+  public captureFrame(): string | null {
+    if (!this.canvas) {
+      console.error('Canvas not available for capture')
+      return null
+    }
+
+    if (!this.composer) {
+      console.error('Composer not initialized for rendering')
+      return null
+    }
+
+    const dataUrl = this.canvas.toDataURL('image/png')
+    return dataUrl
   }
 
   public setSize(): void {

--- a/packages/engine/src/world/Renderer.ts
+++ b/packages/engine/src/world/Renderer.ts
@@ -5,7 +5,8 @@ import { EngineScene } from '@world/EngineScene'
 import { engineScenes } from '@world/scenes'
 
 export class Renderer {
-  public composer: EffectComposer | undefined
+  public composer: EffectComposer
+  public renderer: WebGLRenderer
   private rendererHeight: number = 0
   private rendererWidth: number = 0
   private viewerContainer: HTMLDivElement | undefined
@@ -29,18 +30,19 @@ export class Renderer {
     resizeObserver.observe(el)
   }
 
-  public createCanvas(containerEl: HTMLDivElement): void {
-    const renderer = new WebGLRenderer({
+  constructor() {
+    this.renderer = new WebGLRenderer({
       antialias: false, // Antialiasing should be handled by the composer
       preserveDrawingBuffer: true, // Required for frame capture to work consistently
     })
-    this.composer = new EffectComposer(renderer)
+    this.composer = new EffectComposer(this.renderer)
+  }
 
-    this.canvas = renderer.domElement
+  public createCanvas(containerEl: HTMLDivElement): void {
+    this.canvas = this.renderer.domElement
     containerEl.innerHTML = ''
     containerEl.appendChild(this.canvas)
     this.viewerContainer = containerEl
-
     this.setResizeObserver(containerEl)
   }
 

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -7,7 +7,7 @@ import { EngineScene } from '@world/EngineScene'
 type SketchUpdateParams = {
   deltaFrame: number
   deltaTime: number
-  params: { [key: string]: any }
+  params: { [key: string]: unknown }
   scene: EngineScene
 }
 

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -4,9 +4,16 @@ import { SketchModule } from '@store/types'
 import { getDebugScene } from '@world/debugScene'
 import { EngineScene } from '@world/EngineScene'
 
+type SketchUpdateParams = {
+  deltaFrame: number
+  deltaTime: number
+  params: { [key: string]: any }
+  scene: EngineScene
+}
+
 type SketchInstance = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  update: any
+  update: (arg: SketchUpdateParams) => void
   root?: Group
 
   getPasses?: (engineScene: EngineScene) => Pass[]


### PR DESCRIPTION
From the new markdown...

# Experimental Features in Hedron

This document lists and describes experimental features available in Hedron. These features can be accessed via the developer console (f12).

## Rendering

### Saving an image
`saveFrame()` - Save a timestamped image.

### Saving an image sequence
`renderFrames(count: number, name: string, ffmpeg?: boolean)` - Save a series of images.
Images will be saved to the Documents folder, in a folder named name. It will overwrite any existing files. Each frame will be suffixed with its index. If `ffmpeg` is true, it will try to create a video using ffmpeg (must be installed and made accessible via the command line by the user).  
ffmpeg command as follows:
`ffmpeg -y -framerate 30 -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`

### Testing a video loop
`resetEvery(seconds: number, jumpTo?: number)` - Loop after a given time
`cancelReset()` - Stop the looping
`jumpTo` is used to test the 'loop point' of a video, it will jump to the end, play through to the loop + the opposite of the jump time.
ie; `resetEvery(6, 5)` will play from seconds 5-6, then 6-1, then back to 5.
The way the video loops work is by passing large/negative `deltaTime` values to the sketches. `deltaTime` is a new top-level property that was added to the object passed on sketch `update`
