### PR TITLE
Sketch dispose function

### DIFF
--- a/packages/engine/src/HedronEngine/importSketchModule.ts
+++ b/packages/engine/src/HedronEngine/importSketchModule.ts
@@ -23,8 +23,9 @@ export const importSketchModule = async (
     if ((await fetch(configPath)).status !== 200) {
       // No config file found
       // Try instancing the sketch, and call getConfig() on it
-      const tempModule = new module()
+      const tempModule = new module(undefined)
       config = tempModule.getConfig?.()
+      tempModule.dispose?.()
       if (!config) {
         return Promise.reject(
           `Sketch config not found: ${configPath} and no valid getConfig() function found in sketch`,

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -16,13 +16,23 @@ type SketchInstance = {
   root?: Group
 
   getPasses?: (engineScene: EngineScene) => Pass[]
+
+  /**
+   * Called when the sketch is removed from the scene.
+   * It should clean up any resources, event listeners, or references it holds.
+   */
+  dispose(): () => void
 }
 
 export class SketchManager {
   private sketchInstances: { [id: string]: SketchInstance } = {}
 
-  private createSketch = (instanceId: string, module: SketchModule): SketchInstance => {
-    const sketch = new module(getDebugScene())
+  private createSketch = (
+    instanceId: string,
+    module: SketchModule,
+    scene: EngineScene,
+  ): SketchInstance => {
+    const sketch = new module(scene)
     if (sketch.root) {
       sketch.root.name = instanceId
     }
@@ -33,8 +43,9 @@ export class SketchManager {
   }
 
   public addSketchToScene = (instanceId: string, module: SketchModule): void => {
-    const scene = getDebugScene().scene
-    const sketch = this.createSketch(instanceId, module)
+    const engineScene = getDebugScene()
+    const scene = engineScene.scene
+    const sketch = this.createSketch(instanceId, module, engineScene)
     if (sketch.root) {
       scene.add(sketch.root)
     }
@@ -49,6 +60,7 @@ export class SketchManager {
     }
 
     scene.remove(oldSketch)
+    this.sketchInstances[instanceId]?.dispose?.()
     delete this.sketchInstances[instanceId]
   }
 

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -21,7 +21,7 @@ type SketchInstance = {
    * Called when the sketch is removed from the scene.
    * It should clean up any resources, event listeners, or references it holds.
    */
-  dispose(): () => void
+  dispose(engineScene: EngineScene): () => void
 }
 
 export class SketchManager {
@@ -52,7 +52,8 @@ export class SketchManager {
   }
 
   public removeSketchFromScene = (instanceId: string): void => {
-    const scene = getDebugScene().scene
+    const engineScene = getDebugScene()
+    const scene = engineScene.scene
     const oldSketch = scene.getObjectByName(instanceId)
 
     if (!oldSketch) {
@@ -60,7 +61,7 @@ export class SketchManager {
     }
 
     scene.remove(oldSketch)
-    this.sketchInstances[instanceId]?.dispose?.()
+    this.sketchInstances[instanceId]?.dispose?.(engineScene)
     delete this.sketchInstances[instanceId]
   }
 


### PR DESCRIPTION
Adds an optional `dispose` function to sketches so they can do any cleanup they need.

Not beholden to the name if you think `destroy` would be better, just let me know, I'll update the md with whatever we go with