### PR TITLE
Stop the computer from sleeping with Hedron open

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, screen, session } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, powerSaveBlocker, screen, session } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { REDUX_DEVTOOLS, installExtension } from '@tomjs/electron-devtools-installer'
 import { saveFrameHandler, saveFrameSequenceHandler } from './handlers/frameHandlers'
@@ -17,6 +17,7 @@ import { startSketchesServer } from '@main/handleSketchFiles'
 import { saveProjectFile } from '@main/handlers/saveProjectFile'
 import { openProjectFile } from '@main/handlers/openProjectFile'
 const isDevelopment = process.env.NODE_ENV !== 'production'
+let powerSaveBlockID: number
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -33,6 +34,7 @@ app.whenReady().then(() => {
   // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
+    powerSaveBlockID = powerSaveBlocker.start('prevent-display-sleep')
   })
 
   createWindow()
@@ -82,6 +84,7 @@ export const initiateScreens = (): void => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
+  powerSaveBlocker.stop(powerSaveBlockID)
   if (process.platform !== 'darwin') {
     app.quit()
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, powerSaveBlocker, screen, session } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, screen, session } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { REDUX_DEVTOOLS, installExtension } from '@tomjs/electron-devtools-installer'
 import { saveFrameHandler, saveFrameSequenceHandler } from './handlers/frameHandlers'
@@ -17,7 +17,6 @@ import { startSketchesServer } from '@main/handleSketchFiles'
 import { saveProjectFile } from '@main/handlers/saveProjectFile'
 import { openProjectFile } from '@main/handlers/openProjectFile'
 const isDevelopment = process.env.NODE_ENV !== 'production'
-let powerSaveBlockID: number
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -34,7 +33,6 @@ app.whenReady().then(() => {
   // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
-    powerSaveBlockID = powerSaveBlocker.start('prevent-display-sleep')
   })
 
   createWindow()
@@ -68,8 +66,6 @@ app.whenReady().then(() => {
 const updateDisplays = (): void => {
   const displays = screen.getAllDisplays()
   updateDisplayMenu(displays)
-  // ipcMain.send(ScreenEvents.UpdateDisplays, displays)
-  // store.dispatch(displaysListUpdate(displays))
 }
 
 export const initiateScreens = (): void => {
@@ -84,7 +80,6 @@ export const initiateScreens = (): void => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  powerSaveBlocker.stop(powerSaveBlockID)
   if (process.platform !== 'darwin') {
     app.quit()
   }
@@ -116,6 +111,5 @@ ipcMain.handle(SketchEvents.StartSketchesServer, async (_, sketchesDir: string) 
   return await startSketchesServer(sketchesDir)
 })
 
-// Replace inline frame handling code with imports from handlers/frameHandlers
 ipcMain.handle(FrameEvents.SaveFrame, saveFrameHandler)
 ipcMain.handle(FrameEvents.SaveFrameSequence, saveFrameSequenceHandler)

--- a/packages/desktop/src/main/mainWindow.ts
+++ b/packages/desktop/src/main/mainWindow.ts
@@ -1,9 +1,12 @@
 import { join } from 'path'
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, powerSaveBlocker } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import icon from '@resources/icon.png?asset'
+import { OUTPUT_WINDOW_NAME } from '@shared/constants'
 
 export let mainWindow: BrowserWindow | undefined
+
+let powerSaveBlockID: number
 
 export const getMainWindow = (): BrowserWindow => {
   if (!mainWindow) throw new Error("Can't get main window")
@@ -34,14 +37,21 @@ export const createWindow = (): void => {
   })
 
   mainWindow.webContents.on('did-create-window', (window, { frameName }) => {
-    if (frameName === 'output-canvas') {
+    if (frameName === OUTPUT_WINDOW_NAME) {
       // Wait until window has been moved before setting full screen
       setTimeout(() => {
         window.autoHideMenuBar = true
         window.setMenuBarVisibility(false)
         window.setFullScreen(true)
+        powerSaveBlockID = powerSaveBlocker.start('prevent-display-sleep')
       }, 500)
     }
+
+    window.on('close', () => {
+      if (frameName === OUTPUT_WINDOW_NAME) {
+        powerSaveBlocker.stop(powerSaveBlockID)
+      }
+    })
   })
 
   // HMR for renderer base on electron-vite cli.

--- a/packages/desktop/src/renderer/windows.ts
+++ b/packages/desktop/src/renderer/windows.ts
@@ -1,9 +1,10 @@
 import { Display } from 'electron'
 import { engine } from '@renderer/engine'
 import { ScreenEvents } from '@shared/Events'
+import { OUTPUT_WINDOW_NAME } from '@shared/constants'
 
 export const sendOutput = (display: Display): void => {
-  const outputWin = window.open('', 'output-canvas')
+  const outputWin = window.open('', OUTPUT_WINDOW_NAME)
 
   if (!outputWin) throw new Error("Couldn't open window")
 

--- a/packages/desktop/src/shared/constants.ts
+++ b/packages/desktop/src/shared/constants.ts
@@ -1,0 +1,1 @@
+export const OUTPUT_WINDOW_NAME = 'output-canvas'


### PR DESCRIPTION
What the title says, tells the computer not to fall asleep when the app is open.

Stops any embarrassing interruptions to a show, since computers don't treat midi input as interactions like mouse/keyboard input.