### PR TITLE
Fix error in midi-test-app

### DIFF
--- a/packages/midi-test-app/src/App.tsx
+++ b/packages/midi-test-app/src/App.tsx
@@ -1,5 +1,5 @@
 import './custom.css'
-import { Midi, MIDIEvent, MidiMessageType } from '@hedron/midi-manager'
+import { MidiManager, MIDIEvent } from '@hedron/midi-manager'
 
 const $text = (id: string, text: string) => {
   document.querySelector<HTMLDivElement>(`#${id}`)!.textContent = text
@@ -12,7 +12,7 @@ function App() {
 
   function onMidiMessage(event: MIDIEvent) {
     const statusType = event.type
-    if (statusType === MidiMessageType.Unknown) {
+    if (statusType === undefined) {
       return // my launch pad was sending unknown non-stop, would imagine some other devices do as well
     }
     midiLogs.unshift(
@@ -28,7 +28,7 @@ function App() {
     $text('devices', getMidiDevices())
   }
 
-  const midi: Midi = new Midi()
+  const midi: MidiManager = new MidiManager()
   midi.onDeviceChange.add(onDeviceChange)
   midi.onMidiMessage.add(onMidiMessage)
 


### PR DESCRIPTION
Was failing to build because it was using the old MidiManager class