### PR TITLE
WIP: No sketch crash

### DIFF
--- a/packages/desktop/src/renderer/components/SketchTabs/SketchTabs.tsx
+++ b/packages/desktop/src/renderer/components/SketchTabs/SketchTabs.tsx
@@ -8,9 +8,10 @@ import { useGlobalDialog } from '@components/GlobalDialogs/useGlobalDialog'
 interface ItemProps {
   children: React.ReactNode
   id: string
+  isBroken?: boolean
 }
 
-const Item = ({ id, children }: ItemProps) => {
+const Item = ({ id, children, isBroken }: ItemProps) => {
   const isActive = useIsActiveSketch(id)
   const setActiveSketchId = useSetActiveSketchId()
 
@@ -19,7 +20,7 @@ const Item = ({ id, children }: ItemProps) => {
   }, [id, setActiveSketchId])
 
   return (
-    <SideTabsItem isActive={isActive} onClick={onClick}>
+    <SideTabsItem isActive={isActive} showErrorIcon={isBroken} onClick={onClick}>
       {children}
     </SideTabsItem>
   )
@@ -31,8 +32,8 @@ export const SketchTabs = () => {
 
   return (
     <SideTabs>
-      {sketches.map(({ title, id }) => (
-        <Item key={id} id={id}>
+      {sketches.map(({ title, id, isBroken }) => (
+        <Item key={id} id={id} isBroken={isBroken}>
           {title}
         </Item>
       ))}

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -180,11 +180,21 @@ export class HedronEngine {
       const paramValues = getSketchParamValues(state, sketchId)
       const instance = sketchInstances[sketchId]
       if (instance?.getPasses) {
-        instance.getPasses(engineScene).forEach((pass: Pass) => {
-          engineScene.addPass(pass)
-        })
+        try {
+          instance.getPasses(engineScene).forEach((pass: Pass) => {
+            engineScene.addPass(pass)
+          })
+        } catch (error) {
+          console.error(`Error getting passes for sketch ${sketchId}:`, error)
+          this.sketchManager.removeSketchFromScene(sketchId)
+        }
       }
-      instance?.update({ deltaFrame: 1, deltaTime, params: paramValues, scene: engineScene })
+      try {
+        instance?.update({ deltaFrame: 1, deltaTime, params: paramValues, scene: engineScene })
+      } catch (error) {
+        console.error(`Error updating sketch ${sketchId}:`, error)
+        this.sketchManager.removeSketchFromScene(sketchId)
+      }
     })
     this.renderer.render(engineScene)
   }

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -25,6 +25,7 @@ export class HedronEngine {
   private running: boolean = false
   private paused: boolean = false
   private scene: EngineScene // The main scene for rendering sketches
+  private _onError: (sketchInstanceId: string, type: string) => void
 
   private extraTime: number = 0 // For time manipulation, e.g. for skipping frames
   public totalTime: number = 0 // Total time for the engine, used for resetting time
@@ -32,11 +33,18 @@ export class HedronEngine {
   constructor(params: {
     onFrameStart?: () => void
     onFrameEnd?: () => void
+    onError?: (SketchInstanceId: string, type: string) => void
     rendererType: RendererType
   }) {
     this.rendererType = params.rendererType
     this.store = createEngineStore()
-    this.sketchManager = new SketchManager()
+
+    this._onError = (sketchInstanceId: string, type: string) => {
+      params.onError?.(sketchInstanceId, type)
+      this.store.getState().updateSketch(sketchInstanceId, { isBroken: true })
+    }
+
+    this.sketchManager = new SketchManager({ onError: this._onError })
     this.renderer = new Renderer({ rendererType: this.rendererType })
     this.scene = createDebugScene(this.renderer)
 

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -208,6 +208,7 @@ export class HedronEngine {
         } catch (error) {
           console.error(`Error getting passes for sketch ${sketchId}:`, error)
           this.sketchManager.removeSketchFromScene(sketchId)
+          this.setIsSketchBroken(sketchId, true)
         }
       }
       try {
@@ -215,6 +216,7 @@ export class HedronEngine {
       } catch (error) {
         console.error(`Error updating sketch ${sketchId}:`, error)
         this.sketchManager.removeSketchFromScene(sketchId)
+        this.setIsSketchBroken(sketchId, true)
       }
     })
     this.renderer.render(engineScene)

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -5,7 +5,7 @@ import { importSketchModule } from './importSketchModule'
 import { IPlugin } from '@plugins/Plugin'
 import { stripForSave } from '@utils/stripForSave'
 import { Renderer } from '@world/Renderer'
-import { SketchManager } from '@world/SketchManager'
+import { SketchInstanceError, SketchManager } from '@world/SketchManager'
 import { createDebugScene } from '@world/debugScene'
 import { EngineData, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
@@ -25,7 +25,7 @@ export class HedronEngine {
   private running: boolean = false
   private paused: boolean = false
   private scene: EngineScene // The main scene for rendering sketches
-  private _onError: (sketchInstanceId: string, type: string) => void
+  private _onError: SketchInstanceError
 
   private extraTime: number = 0 // For time manipulation, e.g. for skipping frames
   public totalTime: number = 0 // Total time for the engine, used for resetting time
@@ -33,20 +33,20 @@ export class HedronEngine {
   constructor(params: {
     onFrameStart?: () => void
     onFrameEnd?: () => void
-    onError?: (SketchInstanceId: string, type: string) => void
+    onError?: SketchInstanceError
     rendererType: RendererType
   }) {
     this.rendererType = params.rendererType
     this.store = createEngineStore()
 
-    this._onError = (sketchInstanceId: string, type: string) => {
+    this._onError = (sketchInstanceId, type) => {
       params.onError?.(sketchInstanceId, type)
       this.setIsSketchBroken(sketchInstanceId, true)
     }
 
     this.sketchManager = new SketchManager({ onError: this._onError })
     this.renderer = new Renderer({ rendererType: this.rendererType })
-    this.scene = createDebugScene(this.renderer)
+    this.scene = createDebugScene(this.renderer, this._onError)
 
     this.onFrameStart = params?.onFrameStart
     this.onFrameEnd = params?.onFrameEnd

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -41,7 +41,7 @@ export class HedronEngine {
 
     this._onError = (sketchInstanceId: string, type: string) => {
       params.onError?.(sketchInstanceId, type)
-      this.store.getState().updateSketch(sketchInstanceId, { isBroken: true })
+      this.setIsSketchBroken(sketchInstanceId, true)
     }
 
     this.sketchManager = new SketchManager({ onError: this._onError })
@@ -50,6 +50,10 @@ export class HedronEngine {
 
     this.onFrameStart = params?.onFrameStart
     this.onFrameEnd = params?.onFrameEnd
+  }
+
+  private setIsSketchBroken(sketchInstanceId: string, isBroken: boolean) {
+    this.store.getState().updateSketch(sketchInstanceId, { isBroken })
   }
 
   public registerPlugin(plugin: IPlugin) {
@@ -65,10 +69,15 @@ export class HedronEngine {
 
     const { removeSketchFromScene } = this.sketchManager
 
-    const addSketchToScene = (sketchId: string, moduleId: string) => {
+    const addSketchToScene = (sketchInstanceId: string, moduleId: string) => {
       const modules = this.store.getState().sketchModules
       const module = modules[moduleId].module
-      this.sketchManager.addSketchToScene(sketchId, module)
+
+      const sketchInstance = this.sketchManager.addSketchToScene(sketchInstanceId, module)
+
+      if (sketchInstance) {
+        this.setIsSketchBroken(sketchInstance.id, false)
+      }
 
       this.renderer.passesNeedUpdate_webGPU = true
     }
@@ -109,7 +118,12 @@ export class HedronEngine {
 
     for (const sketch of sketchesToRefresh) {
       this.sketchManager.removeSketchFromScene(sketch.id)
-      this.sketchManager.addSketchToScene(sketch.id, moduleItem.module)
+      const sketchInstance = this.sketchManager.addSketchToScene(sketch.id, moduleItem.module)
+
+      if (sketchInstance) {
+        this.setIsSketchBroken(sketchInstance.id, false)
+      }
+
       this.store.getState().updateSketchParams(sketch.id)
     }
 

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -5,7 +5,7 @@ import { importSketchModule } from './importSketchModule'
 import { IPlugin } from '@plugins/Plugin'
 import { stripForSave } from '@utils/stripForSave'
 import { Renderer } from '@world/Renderer'
-import { SketchManager } from '@world/SketchManager'
+import { SketchInstance, SketchManager } from '@world/SketchManager'
 import { createDebugScene } from '@world/debugScene'
 import { EngineData, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
@@ -170,7 +170,7 @@ export class HedronEngine {
     const sketchInstances = this.sketchManager!.getSketchInstances()
 
     // TODO: When we have scenes, sketches should be added to the scene earlier on
-    engineScene.sketches = Object.values(sketchInstances)
+    engineScene.sketches = Object.values(sketchInstances) as SketchInstance[]
 
     if (this.renderer.rendererType === 'webgl') {
       engineScene.clearPasses()

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -5,7 +5,7 @@ import { importSketchModule } from './importSketchModule'
 import { IPlugin } from '@plugins/Plugin'
 import { stripForSave } from '@utils/stripForSave'
 import { Renderer } from '@world/Renderer'
-import { SketchInstance, SketchManager } from '@world/SketchManager'
+import { SketchManager } from '@world/SketchManager'
 import { createDebugScene } from '@world/debugScene'
 import { EngineData, SketchModuleItem } from '@store/types'
 import { getSketchesOfModuleId } from '@store/selectors/getSketchesOfModuleId'
@@ -189,10 +189,9 @@ export class HedronEngine {
    */
   private advanceFrame(engineScene: EngineScene, deltaTime: number) {
     const state = this.store.getState()
-    const sketchInstances = this.sketchManager!.getSketchInstances()
-
-    // TODO: When we have scenes, sketches should be added to the scene earlier on
-    engineScene.sketches = Object.values(sketchInstances) as SketchInstance[]
+    const sketchInstances =
+      // TODO: When we have scenes, sketches should be added to the scene earlier on
+      (engineScene.sketches = this.sketchManager!.getSketchInstances())
 
     if (this.renderer.rendererType === 'webgl') {
       engineScene.clearPasses()
@@ -200,7 +199,7 @@ export class HedronEngine {
 
     Object.keys(state.sketches).forEach((sketchId) => {
       const paramValues = getSketchParamValues(state, sketchId)
-      const instance = sketchInstances[sketchId]
+      const instance = sketchInstances.get(sketchId)
       if (instance?.getPasses) {
         try {
           instance.getPasses(engineScene).forEach((pass: Pass) => {

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -179,12 +179,12 @@ export class HedronEngine {
     Object.keys(state.sketches).forEach((sketchId) => {
       const paramValues = getSketchParamValues(state, sketchId)
       const instance = sketchInstances[sketchId]
-      if (instance.getPasses) {
+      if (instance?.getPasses) {
         instance.getPasses(engineScene).forEach((pass: Pass) => {
           engineScene.addPass(pass)
         })
       }
-      instance.update({ deltaFrame: 1, deltaTime, params: paramValues, scene: engineScene })
+      instance?.update({ deltaFrame: 1, deltaTime, params: paramValues, scene: engineScene })
     })
     this.renderer.render(engineScene)
   }

--- a/packages/engine/src/store/actionCreators/updateSketch.ts
+++ b/packages/engine/src/store/actionCreators/updateSketch.ts
@@ -1,0 +1,14 @@
+import { SetterCreator } from '@store/types'
+
+export const createUpdateSketch: SetterCreator<'updateSketch'> =
+  (setState) => (instanceId, sketchState) => {
+    setState((state) => {
+      const sketch = state.sketches[instanceId]
+      if (!sketch) return
+
+      state.sketches[instanceId] = {
+        ...sketch,
+        ...sketchState,
+      }
+    })
+  }

--- a/packages/engine/src/store/engineStore.ts
+++ b/packages/engine/src/store/engineStore.ts
@@ -17,6 +17,7 @@ import {
 import { createReset } from '@store/actionCreators/reset'
 import { createLoadProject } from '@store/actionCreators/loadProject'
 import { createAddInput, createUpdateInputOptions } from '@store/actionCreators/createAddInput'
+import { createUpdateSketch } from '@store/actionCreators/updateSketch'
 
 export const createEngineStore = () =>
   createStore<EngineStateWithActions>()(
@@ -25,6 +26,7 @@ export const createEngineStore = () =>
         immer((set) => ({
           ...initialState,
           addSketch: createAddSketch(set),
+          updateSketch: createUpdateSketch(set),
           updateSketchParams: createUpdateSketchParams(set),
           setSketchModuleItem: createSetSketchModuleItem(set),
           updateNodeValue: createUpdateNodeValue(set),

--- a/packages/engine/src/store/types.ts
+++ b/packages/engine/src/store/types.ts
@@ -5,6 +5,7 @@ export interface SketchState {
   title: string
   moduleId: string
   paramIds: string[]
+  isBroken?: boolean
 }
 
 export type Sketches = { [key: string]: SketchState }
@@ -207,6 +208,7 @@ export type EngineState = EngineData & AuxState
 
 interface Actions {
   addSketch: (moduleId: string) => string
+  updateSketch: (instanceId: string, sketchState: Partial<SketchState>) => void
   updateSketchParams: (instanceId: string) => void
   deleteSketch: (instanceId: string) => void
   setSketchModuleItem: (newItem: SketchModuleItem) => void

--- a/packages/engine/src/world/EngineScene.ts
+++ b/packages/engine/src/world/EngineScene.ts
@@ -60,8 +60,12 @@ export class EngineScene {
 
     sketchInstances.forEach((sketchInstance) => {
       if (sketchInstance.getWebGPUPass) {
-        const nextPass = sketchInstance.getWebGPUPass(prevPass)
-        prevPass = nextPass
+        try {
+          const nextPass = sketchInstance.getWebGPUPass(prevPass)
+          prevPass = nextPass
+        } catch (error) {
+          console.error(`Error getting WebGPU pass for sketch instance ${sketchInstance.id}`, error)
+        }
       }
     })
 

--- a/packages/engine/src/world/EngineScene.ts
+++ b/packages/engine/src/world/EngineScene.ts
@@ -2,7 +2,7 @@ import { Pass, RenderPass } from 'postprocessing'
 import { PerspectiveCamera, Scene } from 'three'
 import { pass, type ShaderNodeObject } from 'three/tsl'
 import { PassNode, PostProcessing } from 'three/webgpu'
-import { SketchInstanceMap } from '@world/SketchManager'
+import { SketchInstanceError, SketchInstanceMap } from '@world/SketchManager'
 import { RendererType } from '@HedronEngine/types'
 
 export class EngineScene {
@@ -13,9 +13,17 @@ export class EngineScene {
   private renderPass: RenderPass | undefined
   private renderPass_webGPU: ShaderNodeObject<PassNode> | undefined
   public rendererType: RendererType
+  private onSketchInstanceError: SketchInstanceError
 
-  constructor({ rendererType }: { rendererType: RendererType }) {
+  constructor({
+    rendererType,
+    onSketchInstanceError,
+  }: {
+    rendererType: RendererType
+    onSketchInstanceError: SketchInstanceError
+  }) {
     this.rendererType = rendererType
+    this.onSketchInstanceError = onSketchInstanceError
     this.scene = new Scene()
     this.camera = new PerspectiveCamera(75, undefined, 0.1, 100000)
     this.camera.position.z = 5
@@ -64,6 +72,7 @@ export class EngineScene {
           const nextPass = sketchInstance.getWebGPUPass(prevPass)
           prevPass = nextPass
         } catch (error) {
+          this.onSketchInstanceError(sketchInstance.id)
           console.error(`Error getting WebGPU pass for sketch instance ${sketchInstance.id}`, error)
         }
       }

--- a/packages/engine/src/world/EngineScene.ts
+++ b/packages/engine/src/world/EngineScene.ts
@@ -2,14 +2,14 @@ import { Pass, RenderPass } from 'postprocessing'
 import { PerspectiveCamera, Scene } from 'three'
 import { pass, type ShaderNodeObject } from 'three/tsl'
 import { PassNode, PostProcessing } from 'three/webgpu'
-import { SketchInstance } from '@world/SketchManager'
+import { SketchInstanceMap } from '@world/SketchManager'
 import { RendererType } from '@HedronEngine/types'
 
 export class EngineScene {
   public scene: Scene
   public camera: PerspectiveCamera
   public passes: Pass[] | undefined
-  public sketches: SketchInstance[] = []
+  public sketches: SketchInstanceMap = new Map()
   private renderPass: RenderPass | undefined
   private renderPass_webGPU: ShaderNodeObject<PassNode> | undefined
   public rendererType: RendererType
@@ -50,7 +50,7 @@ export class EngineScene {
     this.passes = [this.renderPass]
   }
 
-  updateWebGPUPasses(sketchInstances: SketchInstance[], postProcessing: PostProcessing): void {
+  updateWebGPUPasses(sketchInstances: SketchInstanceMap, postProcessing: PostProcessing): void {
     if (this.rendererType !== 'webgpu') {
       console.warn('[HEDRON] ⚠️ WebGPU pass handling is only available in WebGPU mode.')
       return

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -14,6 +14,7 @@ type SketchUpdateParams = {
 }
 
 export type SketchInstance = {
+  id: string
   update: (arg: SketchUpdateParams) => void
   root?: Group
 
@@ -37,7 +38,9 @@ export class SketchManager {
     scene: EngineScene,
   ): SketchInstance | undefined => {
     try {
-      const sketch = new module(scene)
+      const sketch = new module(scene) as SketchInstance
+      sketch.id = instanceId
+
       if (sketch.root) {
         sketch.root.name = instanceId
       }

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -29,7 +29,7 @@ export type SketchInstance = {
 }
 
 export class SketchManager {
-  private sketchInstances: { [id: string]: SketchInstance } = {}
+  private sketchInstances: { [id: string]: SketchInstance | undefined } = {}
 
   private createSketch = (
     instanceId: string,

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -36,8 +36,10 @@ export type SketchInstance = {
   dispose(engineScene: EngineScene): () => void
 }
 
+export type SketchInstanceMap = Map<string, SketchInstance>
+
 export class SketchManager {
-  private sketchInstances: { [id: string]: SketchInstance | undefined } = {}
+  private sketchInstances: SketchInstanceMap = new Map()
   private onError: SketchManagerErrorHandler
 
   constructor({ onError }: { onError: SketchManagerErrorHandler }) {
@@ -57,7 +59,7 @@ export class SketchManager {
         sketchInstance.root.name = instanceId
       }
 
-      this.sketchInstances[instanceId] = sketchInstance
+      this.sketchInstances.set(instanceId, sketchInstance)
 
       return sketchInstance
     } catch (error) {
@@ -92,13 +94,13 @@ export class SketchManager {
     }
 
     try {
-      this.sketchInstances[instanceId]?.dispose?.(engineScene)
+      this.sketchInstances.get(instanceId)?.dispose?.(engineScene)
     } catch (error) {
       console.error(`Error disposing sketch instance ${instanceId}:`, error)
       this.onError(instanceId, SketchManagerErrorType.Dispose)
     }
 
-    delete this.sketchInstances[instanceId]
+    this.sketchInstances.delete(instanceId)
   }
 
   public getSketchInstances = () => {

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -13,6 +13,13 @@ type SketchUpdateParams = {
   scene: EngineScene
 }
 
+enum SketchManagerErrorType {
+  Create = 'Create',
+  Dispose = 'Dispose',
+}
+
+type SketchManagerErrorHandler = (sketchInstanceId: string, type: SketchManagerErrorType) => void
+
 export type SketchInstance = {
   id: string
   update: (arg: SketchUpdateParams) => void
@@ -31,6 +38,11 @@ export type SketchInstance = {
 
 export class SketchManager {
   private sketchInstances: { [id: string]: SketchInstance | undefined } = {}
+  private onError: SketchManagerErrorHandler
+
+  constructor({ onError }: { onError: SketchManagerErrorHandler }) {
+    this.onError = onError
+  }
 
   private createSketch = (
     instanceId: string,
@@ -38,19 +50,20 @@ export class SketchManager {
     scene: EngineScene,
   ): SketchInstance | undefined => {
     try {
-      const sketch = new module(scene) as SketchInstance
-      sketch.id = instanceId
+      const sketchInstance = new module(scene) as SketchInstance
+      sketchInstance.id = instanceId
 
-      if (sketch.root) {
-        sketch.root.name = instanceId
+      if (sketchInstance.root) {
+        sketchInstance.root.name = instanceId
       }
 
-      this.sketchInstances[instanceId] = sketch
+      this.sketchInstances[instanceId] = sketchInstance
 
-      return sketch
+      return sketchInstance
     } catch (error) {
       // TODO: error toast
       console.error('Failed to create sketch:', error)
+      this.onError(instanceId, SketchManagerErrorType.Create)
     }
   }
 
@@ -78,6 +91,7 @@ export class SketchManager {
       this.sketchInstances[instanceId]?.dispose?.(engineScene)
     } catch (error) {
       console.error(`Error disposing sketch instance ${instanceId}:`, error)
+      this.onError(instanceId, SketchManagerErrorType.Dispose)
     }
 
     delete this.sketchInstances[instanceId]

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -74,7 +74,12 @@ export class SketchManager {
       scene.remove(oldSketchRoot)
     }
 
-    this.sketchInstances[instanceId]?.dispose?.(engineScene)
+    try {
+      this.sketchInstances[instanceId]?.dispose?.(engineScene)
+    } catch (error) {
+      console.error(`Error disposing sketch instance ${instanceId}:`, error)
+    }
+
     delete this.sketchInstances[instanceId]
   }
 

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -13,12 +13,12 @@ type SketchUpdateParams = {
   scene: EngineScene
 }
 
-enum SketchManagerErrorType {
+enum SketchErrorType {
   Create = 'Create',
   Dispose = 'Dispose',
 }
 
-type SketchManagerErrorHandler = (sketchInstanceId: string, type: SketchManagerErrorType) => void
+type SketchManagerErrorHandler = (sketchInstanceId: string, type?: SketchErrorType) => void
 
 export type SketchInstance = {
   id: string
@@ -37,6 +37,8 @@ export type SketchInstance = {
 }
 
 export type SketchInstanceMap = Map<string, SketchInstance>
+
+export type SketchInstanceError = (sketchInstanceId: string, errorType?: SketchErrorType) => void
 
 export class SketchManager {
   private sketchInstances: SketchInstanceMap = new Map()
@@ -64,7 +66,7 @@ export class SketchManager {
       return sketchInstance
     } catch (error) {
       console.error('Failed to create sketch:', error)
-      this.onError(instanceId, SketchManagerErrorType.Create)
+      this.onError(instanceId, SketchErrorType.Create)
     }
   }
 
@@ -97,7 +99,7 @@ export class SketchManager {
       this.sketchInstances.get(instanceId)?.dispose?.(engineScene)
     } catch (error) {
       console.error(`Error disposing sketch instance ${instanceId}:`, error)
-      this.onError(instanceId, SketchManagerErrorType.Dispose)
+      this.onError(instanceId, SketchErrorType.Dispose)
     }
 
     this.sketchInstances.delete(instanceId)

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -67,13 +67,18 @@ export class SketchManager {
     }
   }
 
-  public addSketchToScene = (instanceId: string, module: SketchModule) => {
+  public addSketchToScene = (
+    instanceId: string,
+    module: SketchModule,
+  ): SketchInstance | undefined => {
     const engineScene = getDebugScene()
     const scene = engineScene.scene
     const sketch = this.createSketch(instanceId, module, engineScene)
     if (sketch?.root) {
       scene.add(sketch.root)
     }
+
+    return sketch
   }
 
   public removeSketchFromScene = (instanceId: string): void => {

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -35,22 +35,27 @@ export class SketchManager {
     instanceId: string,
     module: SketchModule,
     scene: EngineScene,
-  ): SketchInstance => {
-    const sketch = new module(scene)
-    if (sketch.root) {
-      sketch.root.name = instanceId
+  ): SketchInstance | undefined => {
+    try {
+      const sketch = new module(scene)
+      if (sketch.root) {
+        sketch.root.name = instanceId
+      }
+
+      this.sketchInstances[instanceId] = sketch
+
+      return sketch
+    } catch (error) {
+      // TODO: error toast
+      console.error('Failed to create sketch:', error)
     }
-
-    this.sketchInstances[instanceId] = sketch
-
-    return sketch
   }
 
   public addSketchToScene = (instanceId: string, module: SketchModule) => {
     const engineScene = getDebugScene()
     const scene = engineScene.scene
     const sketch = this.createSketch(instanceId, module, engineScene)
-    if (sketch.root) {
+    if (sketch?.root) {
       scene.add(sketch.root)
     }
   }

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -61,7 +61,6 @@ export class SketchManager {
 
       return sketchInstance
     } catch (error) {
-      // TODO: error toast
       console.error('Failed to create sketch:', error)
       this.onError(instanceId, SketchManagerErrorType.Create)
     }

--- a/packages/engine/src/world/debugScene.ts
+++ b/packages/engine/src/world/debugScene.ts
@@ -1,23 +1,31 @@
 // import { BoxGeometry, Mesh, MeshNormalMaterial } from 'three'
 import { createUniqueId } from '@utils/createUniqueId'
-import { addScene } from '@world/scenes'
+import { engineScenes } from '@world/scenes'
 import { EngineScene } from '@world/EngineScene'
 import { Renderer } from '@world/Renderer'
+import { SketchInstanceError } from '@world/SketchManager'
 
 let debugScene: EngineScene | undefined
 
 export const getDebugScene = (): EngineScene => {
-  if (!debugScene) throw new Error('No sketches server url')
+  if (!debugScene) throw new Error('debugScene not ready')
 
   return debugScene
 }
 
-export const createDebugScene = (renderer: Renderer): EngineScene => {
-  const id = createUniqueId()
-  const scene = addScene(id, renderer.rendererType)
-  scene.setRatio(renderer.aspectRatio)
+export const createDebugScene = (
+  renderer: Renderer,
+  onSketchInstanceError: SketchInstanceError,
+): EngineScene => {
+  const sceneId = createUniqueId()
 
-  debugScene = scene
+  const newScene = new EngineScene({
+    rendererType: renderer.rendererType,
+    onSketchInstanceError,
+  })
 
-  return scene
+  debugScene = newScene
+  engineScenes.set(sceneId, newScene)
+
+  return newScene
 }

--- a/packages/engine/src/world/scenes.ts
+++ b/packages/engine/src/world/scenes.ts
@@ -1,11 +1,3 @@
-import { RendererType } from '@HedronEngine/types'
 import { EngineScene } from '@world/EngineScene'
 
 export const engineScenes = new Map<string, EngineScene>()
-
-export const addScene = (sceneId: string, rendererType: RendererType): EngineScene => {
-  const newScene = new EngineScene({ rendererType })
-  engineScenes.set(sceneId, newScene)
-
-  return newScene
-}

--- a/packages/ui-core/src/components/Icon/Icon.tsx
+++ b/packages/ui-core/src/components/Icon/Icon.tsx
@@ -28,6 +28,7 @@ export type IconName =
   | 'video_camera_back'
   | 'photo_camera_back'
   | '360'
+  | 'error'
 
 export const sketchIcon: IconName = 'token'
 export const sceneIcon: IconName = 'panorama'

--- a/packages/ui-core/src/components/SideTabs/SideTabs.module.css
+++ b/packages/ui-core/src/components/SideTabs/SideTabs.module.css
@@ -8,8 +8,11 @@
 .item {
   --inset: 2px;
 
+  position: relative;
   display: block;
   padding: 0.5rem 0.25rem;
+  border-left: 2px solid transparent;
+  border-right: 2px solid transparent;
   font-size: 0.7rem;
   background: var(--bgColorDark3);
   color: white;
@@ -26,6 +29,10 @@
     cursor: default;
   }
 
+  &:global(.isBroken) {
+    border-left-color: var(--dangerColor);
+  }
+
   span {
     transition: inherit;
     display: block;
@@ -35,4 +42,16 @@
     font-size: 1.5em;
     line-height: 0.8;
   }
+}
+
+.errorIcon {
+  color: var(--dangerColor);
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
 }

--- a/packages/ui-core/src/components/SideTabs/SideTabs.tsx
+++ b/packages/ui-core/src/components/SideTabs/SideTabs.tsx
@@ -15,6 +15,7 @@ export interface SideTabsItemProps extends React.HtmlHTMLAttributes<HTMLButtonEl
   isActive?: boolean
   isSeparate?: boolean
   iconName?: IconName
+  showErrorIcon?: boolean
 }
 
 export const SideTabsItem = ({
@@ -22,12 +23,21 @@ export const SideTabsItem = ({
   isActive,
   className,
   iconName,
+  showErrorIcon,
   ...props
 }: SideTabsItemProps) => {
   return (
-    <button className={`${c.item} ${isActive && 'active'} ${className}`} {...props}>
+    <button
+      className={`${c.item} ${isActive && 'active'} ${showErrorIcon && 'isBroken'} ${className}`}
+      {...props}
+    >
       {iconName && <Icon name={iconName} className={c.icon} />}
       <span>{children}</span>
+      {showErrorIcon && (
+        <div className={c.errorIcon}>
+          <Icon name="error" />
+        </div>
+      )}
     </button>
   )
 }

--- a/packages/ui-core/src/stories/SideTabs.stories.tsx
+++ b/packages/ui-core/src/stories/SideTabs.stories.tsx
@@ -36,3 +36,22 @@ export const Simple = () => {
     </SideTabs>
   )
 }
+
+export const HasBrokenItem = () => {
+  const [activeId, setActiveId] = useState(0)
+  return (
+    <SideTabs>
+      {tabs.map((tab, i) => (
+        <SideTabsItem
+          showErrorIcon={i === 2}
+          key={i}
+          onClick={() => setActiveId(i)}
+          isActive={activeId === i}
+        >
+          {tab}
+        </SideTabsItem>
+      ))}
+      <SideTabsItem iconName="add_circle" />
+    </SideTabs>
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "target": "ES2022"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "noImplicitAny": true,
-    "noUncheckedIndexedAccess": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "target": "ES2022"
   }


### PR DESCRIPTION
Extra checks to prevent sketches from crashing the app entirely. Also adds an `isBroken` property to sketches in the `engineStore`, which is being used to have an error state in the sketch tabs.

TODO:

- [x] assess whether to use `noUncheckedIndexedAccess` or not
- [x] some kind of simple error system for popping up errors. We need some basic `onError` option for `engine`. Can use `react-hot-toast` for GUI part. 

Better to not use high level `try/catch` blocks on the engine and just use some callback instead to display a toast, because sometimes the engine knows better and can keep running. For example, `engine.initiateSketchModules` might allow most to succeed and only one to fail. If we have a try/catch wrapping this we have to let all fail. 