### PR TITLE
disable electron backgroundThrottling

### DIFF
--- a/packages/desktop/src/main/mainWindow.ts
+++ b/packages/desktop/src/main/mainWindow.ts
@@ -29,6 +29,7 @@ export const createWindow = (): void => {
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
+      backgroundThrottling: false,
     },
   })
 

--- a/packages/desktop/src/main/mainWindow.ts
+++ b/packages/desktop/src/main/mainWindow.ts
@@ -29,6 +29,9 @@ export const createWindow = (): void => {
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
+      // * backgroundThrottling:false important for Hedron! *
+      // When `true`, the frame loop can pause if the main window is hidden
+      // which is catastrophic for live shows when sending to an external display
       backgroundThrottling: false,
     },
   })


### PR DESCRIPTION
Fixes #537

Unfortunately `backgroundThrottling` can only be enabled/disabled upon the main window being created, so we can't switch on/off throttling when we want, it's all or nothing.