### PR TITLE
Server shutdown

### DIFF
--- a/packages/desktop/src/main/SketchesServer/SketchesServer.ts
+++ b/packages/desktop/src/main/SketchesServer/SketchesServer.ts
@@ -1,18 +1,20 @@
-import path from 'path'
-import { EventEmitter } from 'events'
-import chokidar from 'chokidar'
-import { getPort } from 'get-port-please'
-import { app } from 'electron'
-import * as esbuild from 'esbuild'
-import { emptyDirSync } from 'fs-extra'
-import { createGlobalVarModuleFiles, watchWithDebounce } from './utils'
 import { getEsbuild } from '@main/getUnpackedModules'
 import { FileWatchEvents } from '@shared/Events'
+import chokidar from 'chokidar'
+import { app } from 'electron'
+import * as esbuild from 'esbuild'
+import { EventEmitter } from 'events'
+import { emptyDirSync } from 'fs-extra'
+import { getPort } from 'get-port-please'
+import path from 'path'
+import { createGlobalVarModuleFiles, watchWithDebounce } from './utils'
 
 const HOST = process.platform.startsWith('win') ? 'localhost' : '0.0.0.0'
 
 export class SketchesServer extends EventEmitter {
   private isFirstBuildComplete: boolean
+  private esbuildContext?: esbuild.BuildContext
+  private watcher?: chokidar.FSWatcher
 
   constructor() {
     super()
@@ -56,6 +58,7 @@ export class SketchesServer extends EventEmitter {
         '.glb': 'file',
         '.fbx': 'file',
         '.obj': 'file',
+        '.dae': 'file',
         '.png': 'file',
         '.jpg': 'file',
         '.jpeg': 'file',
@@ -72,6 +75,7 @@ export class SketchesServer extends EventEmitter {
         '.ply': 'text',
         '.frag': 'text',
         '.vert': 'text',
+        '.json': 'text',
       },
       assetNames: '[dir]/[name]-[hash]',
       publicPath: `http://${HOST}:${port}`,
@@ -143,6 +147,30 @@ export class SketchesServer extends EventEmitter {
       this.emit(FileWatchEvents.unlink, id)
     })
 
+    // Store references for shutdown
+    this.esbuildContext = ctx
+    this.watcher = watcher
+
     return { host, port }
+  }
+
+  shutdown = async (): Promise<void> => {
+    try {
+      // Close the watcher if it exists
+      if (this.watcher) {
+        await this.watcher.close()
+        this.watcher = undefined
+      }
+
+      // Stop the esbuild context if it exists
+      if (this.esbuildContext) {
+        await this.esbuildContext.dispose()
+        this.esbuildContext = undefined
+      }
+
+      console.log('[HEDRON] Sketches server shut down successfully')
+    } catch (error) {
+      console.error('[HEDRON] Error shutting down sketches server:', error)
+    }
   }
 }

--- a/packages/desktop/src/main/SketchesServer/SketchesServer.ts
+++ b/packages/desktop/src/main/SketchesServer/SketchesServer.ts
@@ -1,6 +1,6 @@
 import { getEsbuild } from '@main/getUnpackedModules'
 import { FileWatchEvents } from '@shared/Events'
-import chokidar from 'chokidar'
+import chokidar, { FSWatcher } from 'chokidar'
 import { app } from 'electron'
 import * as esbuild from 'esbuild'
 import { EventEmitter } from 'events'
@@ -14,7 +14,7 @@ const HOST = process.platform.startsWith('win') ? 'localhost' : '0.0.0.0'
 export class SketchesServer extends EventEmitter {
   private isFirstBuildComplete: boolean
   private esbuildContext?: esbuild.BuildContext
-  private watcher?: chokidar.FSWatcher
+  private watcher?: FSWatcher
 
   constructor() {
     super()

--- a/packages/desktop/src/main/handleSketchFiles.ts
+++ b/packages/desktop/src/main/handleSketchFiles.ts
@@ -3,6 +3,9 @@ import { FileWatchEvents, SketchesServerResponse, SketchEvents } from '@shared/E
 import { sendToMainWindow } from '@main/mainWindow'
 import { SketchesServer } from '@main/SketchesServer/SketchesServer'
 
+// Track the current server instance
+let currentSketchesServer: SketchesServer | null = null
+
 const getInitialModuleIds = async (dirPath: string): Promise<string[]> => {
   const moduleIds: string[] = []
   const dir = await fs.promises.opendir(dirPath)
@@ -16,8 +19,16 @@ const getInitialModuleIds = async (dirPath: string): Promise<string[]> => {
 }
 
 export const startSketchesServer = async (dirPath: string): Promise<SketchesServerResponse> => {
+  // Shutdown any existing server before starting a new one
+  if (currentSketchesServer) {
+    console.log('[HEDRON] Shutting down existing sketches server')
+    await currentSketchesServer.shutdown()
+    currentSketchesServer = null
+  }
+
   const moduleIds = await getInitialModuleIds(dirPath)
   const sketchesServer = new SketchesServer()
+  currentSketchesServer = sketchesServer
 
   const { host, port } = await sketchesServer.init(dirPath)
 

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -64,6 +64,7 @@ export class HedronEngine {
 
   public registerPlugin(plugin: IPlugin) {
     this.plugins[plugin.id] = plugin
+    ;(window as any)['__HEDRON'].plugins = this.plugins
   }
 
   public async initiateSketchModules(sketchesUrl: string, moduleIds: string[]) {

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -64,7 +64,6 @@ export class HedronEngine {
 
   public registerPlugin(plugin: IPlugin) {
     this.plugins[plugin.id] = plugin
-    ;(window as unknown).__HEDRON.plugins = this.plugins
   }
 
   public async initiateSketchModules(sketchesUrl: string, moduleIds: string[]) {

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -64,7 +64,7 @@ export class HedronEngine {
 
   public registerPlugin(plugin: IPlugin) {
     this.plugins[plugin.id] = plugin
-    ;(window as any)['__HEDRON'].plugins = this.plugins
+    ;(window as unknown).__HEDRON.plugins = this.plugins
   }
 
   public async initiateSketchModules(sketchesUrl: string, moduleIds: string[]) {


### PR DESCRIPTION
Shuts down the existing server before restarting it. On Windows, I meeded to restart the terminal process every time changes were made in the hedron repo,

Also adds a few filetypes to the list, and exposes the plugins on the global __HEDRON object