### PR TITLE
Better project names (windows fix)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -49,7 +49,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^24.3.0",
-    "@types/path-browserify": "^1.0.3",
     "@types/three": "^0.178.1",
     "electron": "37.3.0",
     "electron-builder": "26.0.12",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -39,7 +39,6 @@
     "fs-extra": "^11.3.1",
     "get-port-please": "^3.2.0",
     "lodash.debounce": "^4.0.8",
-    "path-browserify": "^1.0.1",
     "postprocessing": "^6.37.7",
     "react-error-boundary": "^4.1.2",
     "three": "^0.178.0",

--- a/packages/desktop/src/main/handlers/saveProjectFile.ts
+++ b/packages/desktop/src/main/handlers/saveProjectFile.ts
@@ -57,6 +57,8 @@ export const saveProjectFile = async (
 
     return {
       result: 'success',
+      fileName: path.basename(savePath),
+      fileNameWithoutExt: path.basename(savePath, '.json'),
       savePath,
     }
   } catch (err) {

--- a/packages/desktop/src/renderer/handlers/fileHandlers.ts
+++ b/packages/desktop/src/renderer/handlers/fileHandlers.ts
@@ -1,4 +1,3 @@
-import path from 'path-browserify'
 import { ProjectData } from '@hedron/app-store'
 import { appStore } from '@renderer/appStore'
 import { engine, engineStore } from '@renderer/engine'
@@ -84,7 +83,7 @@ export const handleSaveProjectDialog = async (options?: { saveAs?: boolean }) =>
   if (response.result === 'success') {
     appState.setCurrentSavePath(response.savePath)
     appState.addToSaveList({
-      title: path.basename(response.savePath),
+      title: response.fileNameWithoutExt,
       date: Date.now(),
       path: response.savePath,
       numScenes: 1,

--- a/packages/desktop/src/shared/Events.ts
+++ b/packages/desktop/src/shared/Events.ts
@@ -57,6 +57,8 @@ type OpenProjectResponseSuccess = {
 type SaveProjectResponseSuccess = {
   result: 'success'
   savePath: string
+  fileName: string
+  fileNameWithoutExt: string
 }
 
 export type OpenProjectResponse = OpenProjectResponseSuccess | ResponseError | ResponseCanceled

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
       postprocessing:
         specifier: ^6.37.7
         version: 6.37.7(three@0.178.0)
@@ -202,7 +199,7 @@ importers:
         version: 3.1.1(react@19.1.1)
       zustand:
         specifier: ^4.5.7
-        version: 4.5.7(@types/react@18.3.23)(immer@10.1.1)(react@19.1.1)
+        version: 4.5.7(@types/react@19.1.10)(immer@10.1.1)(react@19.1.1)
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -12381,7 +12378,7 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
   tinyrainbow@1.2.0: {}
@@ -12980,6 +12977,14 @@ snapshots:
       use-sync-external-store: 1.5.0(react@19.1.1)
     optionalDependencies:
       '@types/react': 18.3.23
+      immer: 10.1.1
+      react: 19.1.1
+
+  zustand@4.5.7(@types/react@19.1.10)(immer@10.1.1)(react@19.1.1):
+    dependencies:
+      use-sync-external-store: 1.5.0(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
       immer: 10.1.1
       react: 19.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,9 +210,6 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
-      '@types/path-browserify':
-        specifier: ^1.0.3
-        version: 1.0.3
       '@types/three':
         specifier: ^0.178.1
         version: 0.178.1
@@ -1926,9 +1923,6 @@ packages:
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
-
-  '@types/path-browserify@1.0.3':
-    resolution: {integrity: sha512-ZmHivEbNCBtAfcrFeBCiTjdIc2dey0l7oCGNGpSuRTy8jP6UVND7oUowlvDujBy8r2Hoa8bfFUOCiPWfmtkfxw==}
 
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
@@ -7906,8 +7900,6 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/offscreencanvas@2019.7.3': {}
-
-  '@types/path-browserify@1.0.3': {}
 
   '@types/plist@3.0.5':
     dependencies:


### PR DESCRIPTION
Windows was using the entire file path for project names rather than simply the `basename`. This was because we we were using `path-browserify` which wasn't treating the different path styles properly across Windows and POSIX.

This PR fixes the problem by using node's path `basename` on the main process, and returning `fileName` and `fileNameWithExt` whenever saving a file. 