### PR TITLE
Sketch Reorder

### DIFF
--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -36,6 +36,16 @@ export const ActiveSketch = () => {
               icon: 'delete',
               onClick: () => engineStore.getState().deleteSketch(activeSketch.id),
             },
+            {
+              label: 'Move Up',
+              icon: 'edit',
+              onClick: () => engineStore.getState().moveSketchUp(activeSketch.id),
+            },
+            {
+              label: 'Move Down',
+              icon: 'edit',
+              onClick: () => engineStore.getState().moveSketchDown(activeSketch.id),
+            },
           ]}
         >
           <Button type="ghost" iconName="menu" />

--- a/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/packages/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -32,19 +32,19 @@ export const ActiveSketch = () => {
           className="ml-auto"
           items={[
             {
-              label: 'Delete Sketch',
-              icon: 'delete',
-              onClick: () => engineStore.getState().deleteSketch(activeSketch.id),
-            },
-            {
               label: 'Move Up',
-              icon: 'edit',
+              icon: 'arrow_upward',
               onClick: () => engineStore.getState().moveSketchUp(activeSketch.id),
             },
             {
               label: 'Move Down',
-              icon: 'edit',
+              icon: 'arrow_downward',
               onClick: () => engineStore.getState().moveSketchDown(activeSketch.id),
+            },
+            {
+              label: 'Delete Sketch',
+              icon: 'delete',
+              onClick: () => engineStore.getState().deleteSketch(activeSketch.id),
             },
           ]}
         >

--- a/packages/engine/src/store/actionCreators/moveSketchOrder.ts
+++ b/packages/engine/src/store/actionCreators/moveSketchOrder.ts
@@ -1,0 +1,25 @@
+import { SetterCreator } from '@store/types'
+
+export const createMoveSketchUp: SetterCreator<'moveSketchUp'> =
+  (setState) => (instanceId: string) =>
+    setState((state) => {
+      const sketches = Object.entries(state.sketches)
+      const currentIndex = sketches.findIndex(([id]) => id === instanceId)
+      if (currentIndex > 0) {
+        const [currentSketch] = sketches.splice(currentIndex, 1)
+        sketches.splice(currentIndex - 1, 0, currentSketch)
+        state.sketches = Object.fromEntries(sketches)
+      }
+    })
+
+export const createMoveSketchDown: SetterCreator<'moveSketchDown'> =
+  (setState) => (instanceId: string) =>
+    setState((state) => {
+      const sketches = Object.entries(state.sketches)
+      const currentIndex = sketches.findIndex(([id]) => id === instanceId)
+      if (currentIndex < sketches.length - 1) {
+        const [currentSketch] = sketches.splice(currentIndex, 1)
+        sketches.splice(currentIndex + 1, 0, currentSketch)
+        state.sketches = Object.fromEntries(sketches)
+      }
+    })

--- a/packages/engine/src/store/actionCreators/moveSketchOrder.ts
+++ b/packages/engine/src/store/actionCreators/moveSketchOrder.ts
@@ -5,11 +5,13 @@ export const createMoveSketchUp: SetterCreator<'moveSketchUp'> =
     setState((state) => {
       const sketches = Object.entries(state.sketches)
       const currentIndex = sketches.findIndex(([id]) => id === instanceId)
-      if (currentIndex > 0) {
-        const [currentSketch] = sketches.splice(currentIndex, 1)
-        sketches.splice(currentIndex - 1, 0, currentSketch)
-        state.sketches = Object.fromEntries(sketches)
+      if (currentIndex <= 0) {
+        // Can't move the first index up further
+        return
       }
+      const [currentSketch] = sketches.splice(currentIndex, 1)
+      sketches.splice(currentIndex - 1, 0, currentSketch)
+      state.sketches = Object.fromEntries(sketches)
     })
 
 export const createMoveSketchDown: SetterCreator<'moveSketchDown'> =
@@ -17,9 +19,11 @@ export const createMoveSketchDown: SetterCreator<'moveSketchDown'> =
     setState((state) => {
       const sketches = Object.entries(state.sketches)
       const currentIndex = sketches.findIndex(([id]) => id === instanceId)
-      if (currentIndex < sketches.length - 1) {
-        const [currentSketch] = sketches.splice(currentIndex, 1)
-        sketches.splice(currentIndex + 1, 0, currentSketch)
-        state.sketches = Object.fromEntries(sketches)
+      if (currentIndex === -1 || currentIndex >= sketches.length - 1) {
+        // Can't move the last index down further
+        return
       }
+      const [currentSketch] = sketches.splice(currentIndex, 1)
+      sketches.splice(currentIndex + 1, 0, currentSketch)
+      state.sketches = Object.fromEntries(sketches)
     })

--- a/packages/engine/src/store/engineStore.ts
+++ b/packages/engine/src/store/engineStore.ts
@@ -18,6 +18,7 @@ import { createReset } from '@store/actionCreators/reset'
 import { createLoadProject } from '@store/actionCreators/loadProject'
 import { createAddInput } from '@store/actionCreators/createAddInput'
 import { createUpdateSketch } from '@store/actionCreators/updateSketch'
+import { createMoveSketchDown, createMoveSketchUp } from '@store/actionCreators/moveSketchOrder'
 
 export const createEngineStore = () =>
   createStore<EngineStateWithActions>()(
@@ -33,6 +34,8 @@ export const createEngineStore = () =>
           updateMultipleNodeValues: createUpdateMultipleNodeValues(set),
           deleteSketch: createDeleteSketch(set),
           deleteSketchModule: createDeleteSketchModule(set),
+          moveSketchUp: createMoveSketchUp(set),
+          moveSketchDown: createMoveSketchDown(set),
           reset: createReset(set),
           loadProject: createLoadProject(set),
           addInput: createAddInput(set),

--- a/packages/engine/src/store/types.ts
+++ b/packages/engine/src/store/types.ts
@@ -217,6 +217,8 @@ interface Actions {
   updateSketch: (instanceId: string, sketchState: Partial<SketchState>) => void
   updateSketchParams: (instanceId: string) => void
   deleteSketch: (instanceId: string) => void
+  moveSketchUp: (instanceId: string) => void
+  moveSketchDown: (instanceId: string) => void
   setSketchModuleItem: (newItem: SketchModuleItem) => void
   updateNodeValue: (nodeId: string, value: NodeValue) => void
   updateMultipleNodeValues: (nodeIds: string[], values: NodeValue[]) => void

--- a/packages/ui-core/src/components/Icon/Icon.tsx
+++ b/packages/ui-core/src/components/Icon/Icon.tsx
@@ -29,6 +29,8 @@ export type IconName =
   | 'photo_camera_back'
   | '360'
   | 'error'
+  | 'arrow_upward'
+  | 'arrow_downward'
 
 export const sketchIcon: IconName = 'token'
 export const sceneIcon: IconName = 'panorama'


### PR DESCRIPTION
Allows you to reorder sketches by moving them up/down. 

Helpful for organization, essential for experimenting with post effects without needing to destroy and recreate sketches

<img width="1011" height="392" alt="image" src="https://github.com/user-attachments/assets/e797d695-ab47-4be1-9dcb-e95afba1e6b5" />
<img width="1010" height="360" alt="image" src="https://github.com/user-attachments/assets/2488e3e2-fcf5-4d9a-a5f6-73b6768abe33" />
