### PR TITLE
Video Prewarming & Clock Sync

### DIFF
--- a/packages/clock/src/index.ts
+++ b/packages/clock/src/index.ts
@@ -30,6 +30,7 @@ export class Clock {
   private _onNewBeat?: (beatCount: number) => void
   private _onBpmChange?: (bpm: number) => void
   private _onIsRunningChange?: (isRunning: boolean) => void
+  private _manualMode: boolean = false
 
   /**
    * @param bpm Beats per minute
@@ -62,7 +63,9 @@ export class Clock {
         this._beatCount = newBeatCount
       }
 
-      requestAnimationFrame(this.tick)
+      if (!this._manualMode) {
+        requestAnimationFrame(this.tick)
+      }
 
       this._lastTimestamp = timestamp
     }
@@ -328,5 +331,49 @@ export class Clock {
     return () => {
       this._onIsRunningChange = undefined
     }
+  }
+
+  /**
+   * Allow jumping the clock forward/backwards by a specific number of milliseconds.
+   * @param ms The number of milliseconds to jump the clock by. Can be negative to jump backwards.
+   */
+  public jumpMS(ms: number) {
+    const deltaInc = this._beatsPerMs * ms * (1 + this._beatPulseOffset)
+    this._beatDelta += deltaInc
+    this._beatPulseComparisonDelta += deltaInc
+  }
+
+  /**
+   * Enable manual mode for frame sequence rendering.
+   * In manual mode, the clock will not automatically tick via requestAnimationFrame.
+   * Use manualTick() to advance the clock manually.
+   */
+  public enableManualMode = () => {
+    this._manualMode = true
+  }
+
+  /**
+   * Disable manual mode and resume automatic ticking.
+   */
+  public disableManualMode = () => {
+    this._manualMode = false
+    if (this._isRunning) {
+      requestAnimationFrame(this.tick)
+    }
+  }
+
+  /**
+   * Manually tick the clock with a specific timestamp.
+   * This should only be used when in manual mode for frame sequence rendering.
+   * @param timestamp The timestamp to use for this tick
+   */
+  public manualTick = (timestamp: number) => {
+    if (!this._manualMode) {
+      console.warn(
+        'Clock.manualTick() called while not in manual mode. Use enableManualMode() first.',
+      )
+      return
+    }
+    this.tick(timestamp)
   }
 }

--- a/packages/desktop/src/main/handlers/frameHandlers.ts
+++ b/packages/desktop/src/main/handlers/frameHandlers.ts
@@ -58,21 +58,27 @@ export async function saveFrameSequenceHandler(
   name: string,
   video: boolean = false,
   audioPath?: string,
+  frameCount: number = 0,
 ) {
   try {
     const dirPath = getFrameDirPath(name)
+    if (frameCount === 0) {
+      frameCount = base64Array.length
+    }
+    // Padding numbers with 0s based on frame count
+    const padding = frameCount > 0 ? String(frameCount - 1).length : 1
+    const paddedFormat = `%0${padding}d`
+
     if (base64Array && base64Array.length > 0) {
       for (let i = 0; i < base64Array.length; i++) {
-        const filePath = path.join(dirPath, `${name}-${i}.png`)
+        const paddedIndex = String(i).padStart(padding, '0')
+        const filePath = path.join(dirPath, `${name}-${paddedIndex}.png`)
         fs.writeFileSync(filePath, base64Array[i], 'base64')
       }
     }
 
     let videoPath: string | undefined = undefined
     if (video) {
-      // Count the number of PNG files to determine frame count
-      const files = fs.readdirSync(dirPath).filter((f) => f.endsWith('.png'))
-      const frameCount = files.length
       const frameRate = 30
       const videoDuration = frameCount / frameRate
 
@@ -81,7 +87,7 @@ export async function saveFrameSequenceHandler(
 
       let ffmpegCmd: string
       if (!audioPath) {
-        ffmpegCmd = `ffmpeg -y -framerate ${frameRate} -i "${dirPath}/${name}-%d.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
+        ffmpegCmd = `ffmpeg -y -framerate ${frameRate} -i "${dirPath}/${name}-${paddedFormat}.png" -c:v libx264 -pix_fmt yuv420p -crf 18 "${videoPath}"`
       } else {
         const tempAudio = path.join(dirPath, `${name}-temp.wav`)
 
@@ -100,7 +106,7 @@ export async function saveFrameSequenceHandler(
         })
 
         // Then combine video and trimmed audio
-        ffmpegCmd = `ffmpeg -y -framerate ${frameRate} -i "${dirPath}/${name}-%d.png" -i "${tempAudio}" -map 0:v -map 1:a -c:v libx264 -pix_fmt yuv420p -crf 18 -c:a pcm_s16le "${videoPath}"`
+        ffmpegCmd = `ffmpeg -y -framerate ${frameRate} -i "${dirPath}/${name}-${paddedFormat}.png" -i "${tempAudio}" -map 0:v -map 1:a -c:v libx264 -pix_fmt yuv420p -crf 18 -c:a pcm_s16le "${videoPath}"`
         console.log('FFmpeg command:', ffmpegCmd)
 
         // Execute the video creation command

--- a/packages/desktop/src/renderer/components/VideoControls/RenderTab.tsx
+++ b/packages/desktop/src/renderer/components/VideoControls/RenderTab.tsx
@@ -12,6 +12,7 @@ declare global {
       width?: number,
       height?: number,
       audioPath?: string,
+      prewarmFrames?: number,
     ) => Promise<void>
   }
 }
@@ -23,6 +24,7 @@ export interface RenderSettings {
   width: number | null
   height: number | null
   audioPath: string
+  prewarmFrames: number
 }
 
 interface RenderTabProps {
@@ -51,17 +53,26 @@ export function RenderTab({ renderSettings, setRenderSettings }: RenderTabProps)
       console.log = (message: string) => {
         originalConsoleLog(message)
         if (typeof message === 'string') {
-          if (message.includes('Saved frame')) {
+          if (message.includes('Prewarming')) {
+            setRenderingStatus('Prewarming frames...')
+          } else if (message.includes('Prewarm complete')) {
+            setRenderingStatus('Starting render...')
+          } else if (message.includes('Saved frame')) {
             const match = message.match(/Saved frame (\d+) \/ (\d+)/)
             if (match && match[1] && match[2]) {
               processedFrames = parseInt(match[1])
               setProgress(Math.floor((processedFrames / totalFrames) * 100))
               setRenderingStatus(`Rendering frames: ${processedFrames}/${totalFrames}`)
             }
+          } else if (message.includes('All frames rendered')) {
+            setProgress(100)
+            setRenderingStatus('All frames rendered')
           } else if (message.includes('Creating video')) {
             setRenderingStatus('Creating video file...')
           } else if (message.includes('Video created at')) {
             setRenderingStatus('Video created successfully!')
+          } else if (message.includes('Render complete')) {
+            setRenderingStatus('Render completed!')
           }
         }
       }
@@ -74,6 +85,7 @@ export function RenderTab({ renderSettings, setRenderSettings }: RenderTabProps)
         renderSettings.width || undefined,
         renderSettings.height || undefined,
         renderSettings.audioPath || undefined,
+        renderSettings.prewarmFrames || 0,
       )
 
       // Restore console.log
@@ -101,6 +113,9 @@ export function RenderTab({ renderSettings, setRenderSettings }: RenderTabProps)
       setRenderSettings((prev) => ({ ...prev, [name]: checked }))
     } else if (name === 'width' || name === 'height') {
       const numValue = value === '' ? null : Number(value)
+      setRenderSettings((prev) => ({ ...prev, [name]: numValue }))
+    } else if (name === 'frameCount' || name === 'prewarmFrames') {
+      const numValue = value === '' ? 0 : Number(value)
       setRenderSettings((prev) => ({ ...prev, [name]: numValue }))
     } else {
       setRenderSettings((prev) => ({ ...prev, [name]: value }))
@@ -136,6 +151,21 @@ export function RenderTab({ renderSettings, setRenderSettings }: RenderTabProps)
           />
           {Math.round((renderSettings.frameCount / 30) * 10) / 10} seconds at 30fps
         </div>
+      </div>
+
+      <div className={c.formGroup}>
+        Prewarm Frames (to stabilize feedback loops)
+        <input
+          className={c.input}
+          type="number"
+          id="prewarmFrames"
+          name="prewarmFrames"
+          value={renderSettings.prewarmFrames}
+          onChange={handleRenderSettingChange}
+          min="0"
+          disabled={isRendering}
+        />
+        <small>Render frames without saving to stabilize effects before actual render</small>
       </div>
 
       <div className={c.formGroupRow}>

--- a/packages/desktop/src/renderer/components/VideoControls/VideoControls.tsx
+++ b/packages/desktop/src/renderer/components/VideoControls/VideoControls.tsx
@@ -8,6 +8,7 @@ import { RenderTab, type RenderSettings } from './RenderTab'
 // Initialize with default settings
 const defaultRenderSettings: RenderSettings = {
   frameCount: 300, // 10 seconds at 30fps
+  prewarmFrames: 0,
   name: 'hedron-render',
   createVideo: true,
   width: null,

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -14,6 +14,7 @@ declare global {
       width?: number,
       height?: number,
       audioPath?: string,
+      prewarmFrames?: number,
     ) => Promise<void>
     resetEvery: (seconds: number, offset?: number) => void
     cancelReset: () => void
@@ -25,13 +26,22 @@ async function saveFrameViaIPC(
   dataUrl: string,
   name?: string,
   frameIndex?: number | string,
+  frameCount?: number,
 ): Promise<SaveFrameResponse> {
   const base64Data = dataUrl.replace(/^data:image\/png;base64,/, '')
+
+  // Apply padding if we have frameCount
+  let paddedFrameIndex = frameIndex
+  if (frameCount !== undefined && typeof frameIndex === 'number') {
+    const padding = String(frameCount - 1).length
+    paddedFrameIndex = String(frameIndex).padStart(padding, '0')
+  }
+
   const result = (await window.electronApi.ipcRenderer.invoke(
     FrameEvents.SaveFrame,
     base64Data,
     name,
-    frameIndex,
+    paddedFrameIndex,
   )) as SaveFrameResponse
   return result
 }
@@ -62,10 +72,14 @@ window.renderFrames = async (
   width?: number,
   height?: number,
   audioPath?: string,
+  prewarmFrames: number = 0,
 ) => {
   const fps = 30
   const filePaths: string[] = []
-  engine.resetTime() // Reset the engine time before starting
+
+  // Ensure prewarmFrames is a number to prevent string concatenation
+  const prewarm = Number(prewarmFrames) || 0
+  const frames = Number(frameCount)
 
   // Store original size if resizing
   let originalSize: { width: number; height: number } | null = null
@@ -74,28 +88,64 @@ window.renderFrames = async (
     engine.resizeRenderer(width, height)
   }
 
+  if (prewarm > 0) {
+    console.log(`Prewarming ${prewarm} frames...`)
+  }
+
+  engine.resetTime() // Reset the engine time before starting
+  engine.jumpTime(-prewarm / fps) // Jump to time 0 to start from the beginning
+
   if (typeof engine.renderFramesSequence === 'function') {
-    await engine.renderFramesSequence(
-      frameCount,
-      fps,
-      async (dataUrl: string, frameIndex: number | string) => {
-        const result = await saveFrameViaIPC(dataUrl, name, frameIndex)
-        if (result.success && result.path) {
-          filePaths.push(result.path)
-        } else {
-          console.error(`Failed to save frame ${frameIndex}: ${result.error}`)
-        }
-        const frameNum = Number(frameIndex)
-        if (isNaN(frameNum)) {
-          console.log(`Saved frame ${frameCount} / ${frameNum}`)
-        } else if ((frameNum + 1) % 10 === 0 || frameNum === frameCount - 1) {
-          console.log(`Saved frame ${frameNum + 1} / ${frameNum}`)
-        }
-        console.warn(frameNum)
-      },
-      width,
-      height,
-    )
+    // Render total frames including prewarm, but only save frames after prewarm
+    console.log(`Starting renderFramesSequence with ${frames + prewarm} total frames`)
+    try {
+      await engine.renderFramesSequence(
+        frames + prewarm,
+        fps,
+        async (dataUrl: string, frameIndex: number | string) => {
+          const frameNum = Number(frameIndex)
+
+          // Skip saving prewarm frames
+          if (frameNum < prewarm) {
+            if (frameNum === prewarm - 1) {
+              console.log('Prewarm complete, starting render...')
+            }
+            return
+          }
+
+          // Adjust frame index to start from 0 after prewarm
+          const adjustedFrameIndex = frameNum - prewarm
+
+          // Stop saving after we've saved all the frames we need
+          if (adjustedFrameIndex >= frames) {
+            return
+          }
+
+          try {
+            const result = await saveFrameViaIPC(dataUrl, name, adjustedFrameIndex, frames)
+            if (result.success && result.path) {
+              filePaths.push(result.path)
+            } else {
+              console.error(`Failed to save frame ${adjustedFrameIndex}: ${result.error}`)
+            }
+
+            if ((adjustedFrameIndex + 1) % 10 === 0 || adjustedFrameIndex === frames - 1) {
+              console.log(`Saved frame ${adjustedFrameIndex + 1} / ${frames}`)
+            }
+          } catch (error) {
+            console.error(`Error saving frame ${adjustedFrameIndex}:`, error)
+          }
+        },
+        width,
+        height,
+      )
+      console.log('renderFramesSequence completed')
+    } catch (error) {
+      console.error('Error in renderFramesSequence:', error)
+      throw error
+    }
+
+    console.log('All frames rendered')
   } else {
     console.error('engine.renderFramesSequence is not available')
     // Restore original size if needed
@@ -115,12 +165,14 @@ window.renderFrames = async (
   // After all frames, optionally create video
   let videoPath: string | undefined = undefined
   if (video) {
+    console.log('Creating video...')
     const result = await window.electronApi.ipcRenderer.invoke(
       FrameEvents.SaveFrameSequence,
       [], // No base64 array needed, just trigger video creation
       name,
       true,
       audioPath, // Pass the audio path to the IPC call
+      frames, // Pass the frame count for padding calculation
     )
     if (result.success && result.videoPath) {
       videoPath = result.videoPath
@@ -132,6 +184,8 @@ window.renderFrames = async (
       console.error(`Failed to create video: ${result.error}`)
     }
   }
+
+  console.log('Render complete')
 }
 
 // Using window.resetTimeoutId so it can be accessed by other components

--- a/packages/desktop/src/renderer/utils/frameCapture.ts
+++ b/packages/desktop/src/renderer/utils/frameCapture.ts
@@ -93,7 +93,7 @@ window.renderFrames = async (
   }
 
   engine.resetTime() // Reset the engine time before starting
-  engine.jumpTime(-prewarm / fps) // Jump to time 0 to start from the beginning
+  engine.jumpTime(-prewarm / fps) // Jump back by prewarm duration so we will hit 0 on the first saved frame
 
   if (typeof engine.renderFramesSequence === 'function') {
     // Render total frames including prewarm, but only save frames after prewarm

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -397,6 +397,11 @@ export class HedronEngine {
     height?: number,
   ): Promise<void> {
     this.paused = true
+    // Enable manual clock mode to prevent automatic ticking
+    const wasClockRunning = this.clock?.isRunning
+    if (this.clock && wasClockRunning) {
+      this.clock.enableManualMode()
+    }
 
     // Store original size if resizing
     let originalSize: { width: number; height: number } | null = null
@@ -406,7 +411,9 @@ export class HedronEngine {
     }
 
     const frameDuration = 1 / fps
+    const frameDurationMs = frameDuration * 1000
     const padCount = frameCount.toString().length // Zero-pad index based on frame count
+    let accumulatedTime = performance.now()
 
     for (let i = 0; i < frameCount; i++) {
       this.onFrameStart?.()
@@ -417,6 +424,12 @@ export class HedronEngine {
         this.extraTime = 0
       }
       this.totalTime += deltaTime
+      accumulatedTime += frameDurationMs
+
+      // Manually tick the clock with the fixed timestamp
+      if (this.clock && wasClockRunning) {
+        this.clock.manualTick(accumulatedTime)
+      }
 
       this.advanceFrame(this.scene, deltaTime)
       this.onFrameEnd?.()
@@ -432,10 +445,16 @@ export class HedronEngine {
         await new Promise((resolve) => setTimeout(resolve, 1))
       }
     }
+    console.log(`Frame loop completed: ${frameCount} frames rendered`)
 
     // Restore original size after rendering
     if (originalSize) {
       this.resizeRenderer(originalSize.width, originalSize.height)
+    }
+
+    // Disable manual clock mode and resume automatic ticking
+    if (this.clock && wasClockRunning) {
+      this.clock.disableManualMode()
     }
 
     this.paused = false
@@ -446,7 +465,9 @@ export class HedronEngine {
    * @param seconds Number of seconds to jump forward (positive) or backward (negative)
    */
   public jumpTime(seconds: number): void {
+    console.log(`Jumping time by ${seconds} seconds`)
     this.extraTime += seconds
+    this.clock?.jumpMS(seconds * 1000)
   }
 
   /**
@@ -454,6 +475,7 @@ export class HedronEngine {
    */
   public resetTime(): void {
     this.extraTime -= this.totalTime
+    this.clock?.reset()
     console.log(`Resetting time, extraTime: ${this.extraTime}, totalTime: ${this.totalTime}`)
   }
 }


### PR DESCRIPTION
Video can have prewarm frames, that render at the target resolution, but do not save, helpful for letting feedback loops etc. get up and running so you can get a perfect loop.

Video rendering is consistent when using lfos, regardless of render speed or prewarmed frames.

Wanted to get this in before moving video to a plugin, as the code was done, not sure when it'll get moved to plugin, and didn't want it to get lost