### PR TITLE
Show server errors

### DIFF
--- a/packages/app-store/src/appStore.ts
+++ b/packages/app-store/src/appStore.ts
@@ -5,7 +5,7 @@ import { immer } from 'zustand/middleware/immer'
 import type {} from '@redux-devtools/extension' // required for devtools typing
 import { EngineData } from '@hedron/engine'
 
-export type DialogId = 'sketchModules' | 'sketchBuildResult'
+export type DialogId = 'sketchModules' | 'sketchesServerBuildResult'
 
 export interface BuildMessage {
   text: string
@@ -53,7 +53,7 @@ export interface AppState {
   globalDialogId: DialogId | null
   currentSavePath: string | null
   saveList: SaveItem[]
-  buildResult: BuildResult | null
+  sketchesServerBuildResult: BuildResult | null
   setSelectedNode: (sketchID: string | null, nodeId: string) => void
   setSelectedInput: (nodeId: string, inputId: string) => void
   setOpenedControlGroup: (sketchId: string, groupIndex: number, isOpen: boolean) => void
@@ -63,7 +63,7 @@ export interface AppState {
   setCurrentSavePath: (path: string) => void
   addToSaveList: (path: SaveItem) => void
   removeFromSaveList: (path: string) => void
-  setBuildResult: (result: BuildResult | null) => void
+  setSketchesServerBuildResult: (result: BuildResult | null) => void
 }
 
 export type SetState = StoreApi<AppState>['setState']
@@ -92,7 +92,7 @@ export const createAppStore = () =>
             selectedInputs: {},
             openedControlGroups: {},
             saveList: [],
-            buildResult: null,
+            sketchesServerBuildResult: null,
             setActiveSketchId: (id: string) => {
               set((state) => {
                 state.activeSketchId = id
@@ -127,9 +127,9 @@ export const createAppStore = () =>
                 }
               })
             },
-            setBuildResult: (result: BuildResult | null) => {
+            setSketchesServerBuildResult: (result: BuildResult | null) => {
               set((state) => {
-                state.buildResult = result
+                state.sketchesServerBuildResult = result
               })
             },
             setSelectedNode: (sketchID, nodeId) => {

--- a/packages/app-store/src/appStore.ts
+++ b/packages/app-store/src/appStore.ts
@@ -5,9 +5,9 @@ import { immer } from 'zustand/middleware/immer'
 import type {} from '@redux-devtools/extension' // required for devtools typing
 import { EngineData } from '@hedron/engine'
 
-export type DialogId = 'sketchModules' | 'sketchBuildErrors'
+export type DialogId = 'sketchModules' | 'sketchBuildResult'
 
-export interface BuildError {
+export interface BuildMessage {
   text: string
   location?: {
     file: string
@@ -15,6 +15,11 @@ export interface BuildError {
     column: number
     lineText: string
   } | null
+}
+
+export interface BuildResult {
+  errors: BuildMessage[]
+  warnings: BuildMessage[]
 }
 
 export interface SaveItem {
@@ -48,7 +53,7 @@ export interface AppState {
   globalDialogId: DialogId | null
   currentSavePath: string | null
   saveList: SaveItem[]
-  buildErrors: BuildError[]
+  buildResult: BuildResult | null
   setSelectedNode: (sketchID: string | null, nodeId: string) => void
   setSelectedInput: (nodeId: string, inputId: string) => void
   setOpenedControlGroup: (sketchId: string, groupIndex: number, isOpen: boolean) => void
@@ -58,7 +63,7 @@ export interface AppState {
   setCurrentSavePath: (path: string) => void
   addToSaveList: (path: SaveItem) => void
   removeFromSaveList: (path: string) => void
-  setBuildErrors: (errors: BuildError[]) => void
+  setBuildResult: (result: BuildResult | null) => void
 }
 
 export type SetState = StoreApi<AppState>['setState']
@@ -87,7 +92,7 @@ export const createAppStore = () =>
             selectedInputs: {},
             openedControlGroups: {},
             saveList: [],
-            buildErrors: [],
+            buildResult: null,
             setActiveSketchId: (id: string) => {
               set((state) => {
                 state.activeSketchId = id
@@ -122,9 +127,9 @@ export const createAppStore = () =>
                 }
               })
             },
-            setBuildErrors: (errors: BuildError[]) => {
+            setBuildResult: (result: BuildResult | null) => {
               set((state) => {
-                state.buildErrors = errors
+                state.buildResult = result
               })
             },
             setSelectedNode: (sketchID, nodeId) => {

--- a/packages/app-store/src/appStore.ts
+++ b/packages/app-store/src/appStore.ts
@@ -5,7 +5,17 @@ import { immer } from 'zustand/middleware/immer'
 import type {} from '@redux-devtools/extension' // required for devtools typing
 import { EngineData } from '@hedron/engine'
 
-export type DialogId = 'sketchModules'
+export type DialogId = 'sketchModules' | 'sketchBuildErrors'
+
+export interface BuildError {
+  text: string
+  location?: {
+    file: string
+    line: number
+    column: number
+    lineText: string
+  } | null
+}
 
 export interface SaveItem {
   title: string
@@ -38,6 +48,7 @@ export interface AppState {
   globalDialogId: DialogId | null
   currentSavePath: string | null
   saveList: SaveItem[]
+  buildErrors: BuildError[]
   setSelectedNode: (sketchID: string | null, nodeId: string) => void
   setSelectedInput: (nodeId: string, inputId: string) => void
   setOpenedControlGroup: (sketchId: string, groupIndex: number, isOpen: boolean) => void
@@ -47,6 +58,7 @@ export interface AppState {
   setCurrentSavePath: (path: string) => void
   addToSaveList: (path: SaveItem) => void
   removeFromSaveList: (path: string) => void
+  setBuildErrors: (errors: BuildError[]) => void
 }
 
 export type SetState = StoreApi<AppState>['setState']
@@ -75,6 +87,7 @@ export const createAppStore = () =>
             selectedInputs: {},
             openedControlGroups: {},
             saveList: [],
+            buildErrors: [],
             setActiveSketchId: (id: string) => {
               set((state) => {
                 state.activeSketchId = id
@@ -107,6 +120,11 @@ export const createAppStore = () =>
                 return {
                   saveList: state.saveList.filter((item) => item.path !== path),
                 }
+              })
+            },
+            setBuildErrors: (errors: BuildError[]) => {
+              set((state) => {
+                state.buildErrors = errors
               })
             },
             setSelectedNode: (sketchID, nodeId) => {

--- a/packages/desktop/src/main/SketchesServer/SketchesServer.ts
+++ b/packages/desktop/src/main/SketchesServer/SketchesServer.ts
@@ -105,20 +105,16 @@ export class SketchesServer extends EventEmitter {
           name: 'on-end',
           setup: (build): void => {
             build.onEnd((result) => {
-              // Emit build errors if any
-              if (result.errors.length > 0) {
-                this.emit(FileWatchEvents.buildErrors, result.errors)
-              }
+              const filteredWarnings = result.warnings.filter(
+                // Glob warnings are ok to ignore, as its looking for both .ts and .js files, but there will always be one of them missing
+                (warning) => warning.id !== 'empty-glob',
+              )
 
-              // Emit build warnings if any
-              if (result.warnings.length > 0) {
-                this.emit(FileWatchEvents.buildWarnings, result.warnings)
-              }
-
-              // Emit success if no errors
-              if (result.errors.length === 0) {
-                this.emit(FileWatchEvents.buildSuccess)
-              }
+              // Emit build result with errors and warnings
+              this.emit(FileWatchEvents.buildResult, {
+                errors: result.errors,
+                warnings: filteredWarnings,
+              })
 
               // setTimeout is needed because chokidar is overly sensitive and firing change events after first build is complete
               setTimeout(() => {

--- a/packages/desktop/src/main/SketchesServer/SketchesServer.ts
+++ b/packages/desktop/src/main/SketchesServer/SketchesServer.ts
@@ -104,7 +104,22 @@ export class SketchesServer extends EventEmitter {
         {
           name: 'on-end',
           setup: (build): void => {
-            build.onEnd(() => {
+            build.onEnd((result) => {
+              // Emit build errors if any
+              if (result.errors.length > 0) {
+                this.emit(FileWatchEvents.buildErrors, result.errors)
+              }
+
+              // Emit build warnings if any
+              if (result.warnings.length > 0) {
+                this.emit(FileWatchEvents.buildWarnings, result.warnings)
+              }
+
+              // Emit success if no errors
+              if (result.errors.length === 0) {
+                this.emit(FileWatchEvents.buildSuccess)
+              }
+
               // setTimeout is needed because chokidar is overly sensitive and firing change events after first build is complete
               setTimeout(() => {
                 this.isFirstBuildComplete = true

--- a/packages/desktop/src/main/handleSketchFiles.ts
+++ b/packages/desktop/src/main/handleSketchFiles.ts
@@ -47,18 +47,8 @@ export const startSketchesServer = async (dirPath: string): Promise<SketchesServ
     sendToMainWindow(SketchEvents.RemoveSketchModule, moduleId)
   })
 
-  sketchesServer.on(FileWatchEvents.buildErrors, (errors) => {
-    console.log('Build errors:', errors)
-    sendToMainWindow(SketchEvents.BuildErrors, errors)
-  })
-
-  sketchesServer.on(FileWatchEvents.buildWarnings, (warnings) => {
-    console.log('Build warnings:', warnings)
-    sendToMainWindow(SketchEvents.BuildWarnings, warnings)
-  })
-
-  sketchesServer.on(FileWatchEvents.buildSuccess, () => {
-    sendToMainWindow(SketchEvents.BuildSuccess)
+  sketchesServer.on(FileWatchEvents.buildResult, (result) => {
+    sendToMainWindow(SketchEvents.BuildResult, result)
   })
 
   const url = `http://${host}:${port}`

--- a/packages/desktop/src/main/handleSketchFiles.ts
+++ b/packages/desktop/src/main/handleSketchFiles.ts
@@ -47,6 +47,20 @@ export const startSketchesServer = async (dirPath: string): Promise<SketchesServ
     sendToMainWindow(SketchEvents.RemoveSketchModule, moduleId)
   })
 
+  sketchesServer.on(FileWatchEvents.buildErrors, (errors) => {
+    console.log('Build errors:', errors)
+    sendToMainWindow(SketchEvents.BuildErrors, errors)
+  })
+
+  sketchesServer.on(FileWatchEvents.buildWarnings, (warnings) => {
+    console.log('Build warnings:', warnings)
+    sendToMainWindow(SketchEvents.BuildWarnings, warnings)
+  })
+
+  sketchesServer.on(FileWatchEvents.buildSuccess, () => {
+    sendToMainWindow(SketchEvents.BuildSuccess)
+  })
+
   const url = `http://${host}:${port}`
 
   return { url, moduleIds }

--- a/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
@@ -6,7 +6,7 @@ import { DialogId } from '@renderer/appStore'
 
 const dialogs: { [key in DialogId]: (props: GlobalDialogProps) => JSX.Element } = {
   sketchModules: SketchModulesDialog,
-  sketchBuildErrors: SketchBuildErrorDialog,
+  sketchBuildResult: SketchBuildErrorDialog,
 }
 
 export const GlobalDialogs = () => {

--- a/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
@@ -1,10 +1,12 @@
 import { useGlobalDialog } from '@components/GlobalDialogs/useGlobalDialog'
 import { SketchModulesDialog } from '@components/GlobalDialogs/SketchModulesDialog'
+import { SketchBuildErrorDialog } from '@components/GlobalDialogs/SketchBuildErrorDialog'
 import { GlobalDialogProps } from '@components/GlobalDialogs/types'
 import { DialogId } from '@renderer/appStore'
 
 const dialogs: { [key in DialogId]: (props: GlobalDialogProps) => JSX.Element } = {
   sketchModules: SketchModulesDialog,
+  sketchBuildErrors: SketchBuildErrorDialog,
 }
 
 export const GlobalDialogs = () => {

--- a/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/GlobalDialogs.tsx
@@ -6,7 +6,7 @@ import { DialogId } from '@renderer/appStore'
 
 const dialogs: { [key in DialogId]: (props: GlobalDialogProps) => JSX.Element } = {
   sketchModules: SketchModulesDialog,
-  sketchBuildResult: SketchBuildErrorDialog,
+  sketchesServerBuildResult: SketchBuildErrorDialog,
 }
 
 export const GlobalDialogs = () => {

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
@@ -1,48 +1,57 @@
-.errorList {
+.messageList {
   display: flex;
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
 }
 
-.errorItem {
+.messageItem {
   background: var(--color-bg-2);
-  border-radius: 0.5rem;
   padding: 1rem;
+}
+
+.messageItem.error {
+  font-size: 1.25em;
   border-left: 3px solid var(--errorTextColor);
 }
 
-.errorText {
-  color: var(--errorTextColor);
+.messageItem.warning {
+  font-size: 1.25em;
+  border-left: 3px solid var(--color-warning, #ffaa00);
+}
+
+.messageText {
   font-weight: 600;
   margin-bottom: 0.5rem;
 }
 
-.errorLocation {
+.error .messageText {
+  color: var(--errorTextColor);
+}
+
+.warning .messageText {
+  color: var(--color-warning, #ffaa00);
+}
+
+.messageLocation {
   font-family: monospace;
   font-size: 0.85rem;
   color: var(--color-text-2);
 }
 
-.errorFile {
+.messageFile {
   color: var(--color-text-1);
 }
 
-.errorLine {
+.messageLine {
   color: var(--color-text-3);
 }
 
-.errorLineText {
+.messageLineText {
   margin-top: 0.5rem;
   padding: 0.5rem;
   background: var(--color-bg-1);
   border-radius: 0.25rem;
   overflow-x: auto;
   white-space: pre;
-}
-
-.actions {
-  padding: 1rem;
-  display: flex;
-  justify-content: flex-end;
 }

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
@@ -1,0 +1,48 @@
+.errorList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.errorItem {
+  background: var(--color-bg-2);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  border-left: 3px solid var(--errorTextColor);
+}
+
+.errorText {
+  color: var(--errorTextColor);
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.errorLocation {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: var(--color-text-2);
+}
+
+.errorFile {
+  color: var(--color-text-1);
+}
+
+.errorLine {
+  color: var(--color-text-3);
+}
+
+.errorLineText {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: var(--color-bg-1);
+  border-radius: 0.25rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.actions {
+  padding: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.module.css
@@ -17,7 +17,7 @@
 
 .messageItem.warning {
   font-size: 1.25em;
-  border-left: 3px solid var(--color-warning, #ffaa00);
+  border-left: 3px solid var(--warningTextColor);
 }
 
 .messageText {
@@ -30,27 +30,17 @@
 }
 
 .warning .messageText {
-  color: var(--color-warning, #ffaa00);
+  color: var(--warningTextColor);
 }
 
 .messageLocation {
   font-family: monospace;
   font-size: 0.85rem;
-  color: var(--color-text-2);
-}
-
-.messageFile {
-  color: var(--color-text-1);
-}
-
-.messageLine {
-  color: var(--color-text-3);
 }
 
 .messageLineText {
   margin-top: 0.5rem;
   padding: 0.5rem;
-  background: var(--color-bg-1);
   border-radius: 0.25rem;
   overflow-x: auto;
   white-space: pre;

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
@@ -1,0 +1,36 @@
+import { Dialog, Panel, PanelBody, PanelHeader } from '@hedron/ui-core'
+import styles from './SketchBuildErrorDialog.module.css'
+import { useAppStore, BuildError } from '@renderer/appStore'
+import { GlobalDialogProps } from '@components/GlobalDialogs/types'
+
+export const SketchBuildErrorDialog = ({ closeDialog }: GlobalDialogProps) => {
+  const buildErrors = useAppStore((state) => state.buildErrors)
+
+  return (
+    <Dialog onBackgroundClick={closeDialog}>
+      <Panel width="full" height="full" style={{ maxWidth: '50rem', maxHeight: '80vh' }}>
+        <PanelHeader iconName="error" buttonOnClick={closeDialog}>
+          Sketch Build Errors
+        </PanelHeader>
+        <PanelBody scrollable={true}>
+          <div className={styles.errorList}>
+            {buildErrors.map((error: BuildError, index: number) => (
+              <div key={index} className={styles.errorItem}>
+                <div className={styles.errorText}>{error.text}</div>
+                {error.location && (
+                  <div className={styles.errorLocation}>
+                    <span className={styles.errorFile}>{error.location.file}</span>
+                    <span className={styles.errorLine}>
+                      :{error.location.line}:{error.location.column}
+                    </span>
+                    <pre className={styles.errorLineText}>{error.location.lineText}</pre>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </PanelBody>
+      </Panel>
+    </Dialog>
+  )
+}

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
@@ -24,7 +24,7 @@ const MessageItem = ({ message, type }: MessageItemProps) => (
 )
 
 export const SketchBuildErrorDialog = ({ closeDialog }: GlobalDialogProps) => {
-  const buildResult = useAppStore((state) => state.buildResult)
+  const buildResult = useAppStore((state) => state.sketchesServerBuildResult)
 
   const errors = buildResult?.errors ?? []
   const warnings = buildResult?.warnings ?? []

--- a/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
+++ b/packages/desktop/src/renderer/components/GlobalDialogs/SketchBuildErrorDialog.tsx
@@ -1,32 +1,51 @@
 import { Dialog, Panel, PanelBody, PanelHeader } from '@hedron/ui-core'
 import styles from './SketchBuildErrorDialog.module.css'
-import { useAppStore, BuildError } from '@renderer/appStore'
+import { useAppStore, BuildMessage } from '@renderer/appStore'
 import { GlobalDialogProps } from '@components/GlobalDialogs/types'
 
+interface MessageItemProps {
+  message: BuildMessage
+  type: 'error' | 'warning'
+}
+
+const MessageItem = ({ message, type }: MessageItemProps) => (
+  <div className={`${styles.messageItem} ${styles[type]}`}>
+    <div className={styles.messageText}>{message.text}</div>
+    {message.location && (
+      <div className={styles.messageLocation}>
+        <span className={styles.messageFile}>{message.location.file}</span>
+        <span className={styles.messageLine}>
+          :{message.location.line}:{message.location.column}
+        </span>
+        <pre className={styles.messageLineText}>{message.location.lineText}</pre>
+      </div>
+    )}
+  </div>
+)
+
 export const SketchBuildErrorDialog = ({ closeDialog }: GlobalDialogProps) => {
-  const buildErrors = useAppStore((state) => state.buildErrors)
+  const buildResult = useAppStore((state) => state.buildResult)
+
+  const errors = buildResult?.errors ?? []
+  const warnings = buildResult?.warnings ?? []
+
+  const hasErrors = errors.length > 0
+  const hasWarnings = warnings.length > 0
 
   return (
     <Dialog onBackgroundClick={closeDialog}>
       <Panel width="full" height="full" style={{ maxWidth: '50rem', maxHeight: '80vh' }}>
         <PanelHeader iconName="error" buttonOnClick={closeDialog}>
-          Sketch Build Errors
+          Sketch Build {hasErrors ? 'Errors' : 'Warnings'}{' '}
+          {hasErrors && hasWarnings && `(+ ${warnings.length} warnings)`}
         </PanelHeader>
         <PanelBody scrollable={true}>
-          <div className={styles.errorList}>
-            {buildErrors.map((error: BuildError, index: number) => (
-              <div key={index} className={styles.errorItem}>
-                <div className={styles.errorText}>{error.text}</div>
-                {error.location && (
-                  <div className={styles.errorLocation}>
-                    <span className={styles.errorFile}>{error.location.file}</span>
-                    <span className={styles.errorLine}>
-                      :{error.location.line}:{error.location.column}
-                    </span>
-                    <pre className={styles.errorLineText}>{error.location.lineText}</pre>
-                  </div>
-                )}
-              </div>
+          <div className={styles.messageList}>
+            {errors.map((error, index) => (
+              <MessageItem key={`error-${index}`} message={error} type="error" />
+            ))}
+            {warnings.map((warning, index) => (
+              <MessageItem key={`warning-${index}`} message={warning} type="warning" />
             ))}
           </div>
         </PanelBody>

--- a/packages/desktop/src/renderer/ipc/mainThreadListen.ts
+++ b/packages/desktop/src/renderer/ipc/mainThreadListen.ts
@@ -1,7 +1,7 @@
 import { engine } from '@renderer/engine'
 import { handleLoadProjectDialog, handleSaveProjectDialog } from '@renderer/handlers/fileHandlers'
 import { AppMenuEvents, AppMenuEventsItem, SketchEvents } from '@shared/Events'
-import { appStore, BuildError } from '@renderer/appStore'
+import { appStore, BuildResult } from '@renderer/appStore'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const listen = (event: string, cb: (info: any) => void): void => {
@@ -22,18 +22,19 @@ listen(SketchEvents.RemoveSketchModule, (moduleId: string) => {
   engine.removeSketchModule(moduleId)
 })
 
-listen(SketchEvents.BuildErrors, (errors: BuildError[]) => {
-  appStore.getState().setBuildErrors(errors)
-  appStore.getState().setGlobalDialogId('sketchBuildErrors')
-})
+listen(SketchEvents.BuildResult, (result: BuildResult) => {
+  const state = appStore.getState()
 
-listen(SketchEvents.BuildWarnings, (warnings) => {
-  console.warn('[Hedron] Build warnings:', warnings)
-})
-
-listen(SketchEvents.BuildSuccess, () => {
-  // Clear any existing build errors on successful build
-  appStore.getState().setBuildErrors([])
+  if (result.errors.length > 0) {
+    state.setBuildResult(result)
+    state.setGlobalDialogId('sketchBuildResult')
+  } else {
+    // Clear build result on successful build with no errors
+    state.setBuildResult(null)
+    if (state.globalDialogId === 'sketchBuildResult') {
+      state.setGlobalDialogId(null)
+    }
+  }
 })
 
 listen(AppMenuEvents.AppMenuClick, (item: AppMenuEventsItem) => {

--- a/packages/desktop/src/renderer/ipc/mainThreadListen.ts
+++ b/packages/desktop/src/renderer/ipc/mainThreadListen.ts
@@ -1,6 +1,7 @@
 import { engine } from '@renderer/engine'
 import { handleLoadProjectDialog, handleSaveProjectDialog } from '@renderer/handlers/fileHandlers'
 import { AppMenuEvents, AppMenuEventsItem, SketchEvents } from '@shared/Events'
+import { appStore, BuildError } from '@renderer/appStore'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const listen = (event: string, cb: (info: any) => void): void => {
@@ -21,16 +22,18 @@ listen(SketchEvents.RemoveSketchModule, (moduleId: string) => {
   engine.removeSketchModule(moduleId)
 })
 
-listen(SketchEvents.BuildErrors, (errors) => {
-  console.log('[Hedron] Build errors:', errors)
+listen(SketchEvents.BuildErrors, (errors: BuildError[]) => {
+  appStore.getState().setBuildErrors(errors)
+  appStore.getState().setGlobalDialogId('sketchBuildErrors')
 })
 
 listen(SketchEvents.BuildWarnings, (warnings) => {
-  console.log('[Hedron] Build warnings:', warnings)
+  console.warn('[Hedron] Build warnings:', warnings)
 })
 
 listen(SketchEvents.BuildSuccess, () => {
-  console.log('[Hedron] Build successful')
+  // Clear any existing build errors on successful build
+  appStore.getState().setBuildErrors([])
 })
 
 listen(AppMenuEvents.AppMenuClick, (item: AppMenuEventsItem) => {

--- a/packages/desktop/src/renderer/ipc/mainThreadListen.ts
+++ b/packages/desktop/src/renderer/ipc/mainThreadListen.ts
@@ -21,6 +21,18 @@ listen(SketchEvents.RemoveSketchModule, (moduleId: string) => {
   engine.removeSketchModule(moduleId)
 })
 
+listen(SketchEvents.BuildErrors, (errors) => {
+  console.log('[Hedron] Build errors:', errors)
+})
+
+listen(SketchEvents.BuildWarnings, (warnings) => {
+  console.log('[Hedron] Build warnings:', warnings)
+})
+
+listen(SketchEvents.BuildSuccess, () => {
+  console.log('[Hedron] Build successful')
+})
+
 listen(AppMenuEvents.AppMenuClick, (item: AppMenuEventsItem) => {
   switch (item) {
     case AppMenuEventsItem.Save:

--- a/packages/desktop/src/renderer/ipc/mainThreadListen.ts
+++ b/packages/desktop/src/renderer/ipc/mainThreadListen.ts
@@ -26,12 +26,12 @@ listen(SketchEvents.BuildResult, (result: BuildResult) => {
   const state = appStore.getState()
 
   if (result.errors.length > 0) {
-    state.setBuildResult(result)
-    state.setGlobalDialogId('sketchBuildResult')
+    state.setSketchesServerBuildResult(result)
+    state.setGlobalDialogId('sketchesServerBuildResult')
   } else {
     // Clear build result on successful build with no errors
-    state.setBuildResult(null)
-    if (state.globalDialogId === 'sketchBuildResult') {
+    state.setSketchesServerBuildResult(null)
+    if (state.globalDialogId === 'sketchesServerBuildResult') {
       state.setGlobalDialogId(null)
     }
   }

--- a/packages/desktop/src/shared/Events.ts
+++ b/packages/desktop/src/shared/Events.ts
@@ -6,6 +6,9 @@ export enum SketchEvents {
   ReimportSketchModule = 'reimport-sketch-module',
   AddSketchModule = 'add-sketch-module',
   RemoveSketchModule = 'remove-sketch-module',
+  BuildErrors = 'build-errors',
+  BuildWarnings = 'build-warnings',
+  BuildSuccess = 'build-success',
 }
 
 export interface SketchesServerResponse {
@@ -70,4 +73,7 @@ export enum FileWatchEvents {
   change = 'change',
   unlink = 'unlink',
   add = 'add',
+  buildErrors = 'buildErrors',
+  buildWarnings = 'buildWarnings',
+  buildSuccess = 'buildSuccess',
 }

--- a/packages/desktop/src/shared/Events.ts
+++ b/packages/desktop/src/shared/Events.ts
@@ -6,9 +6,7 @@ export enum SketchEvents {
   ReimportSketchModule = 'reimport-sketch-module',
   AddSketchModule = 'add-sketch-module',
   RemoveSketchModule = 'remove-sketch-module',
-  BuildErrors = 'build-errors',
-  BuildWarnings = 'build-warnings',
-  BuildSuccess = 'build-success',
+  BuildResult = 'build-result',
 }
 
 export interface SketchesServerResponse {
@@ -73,7 +71,5 @@ export enum FileWatchEvents {
   change = 'change',
   unlink = 'unlink',
   add = 'add',
-  buildErrors = 'buildErrors',
-  buildWarnings = 'buildWarnings',
-  buildSuccess = 'buildSuccess',
+  buildResult = 'buildResult',
 }

--- a/packages/ui-core/src/css/variables.css
+++ b/packages/ui-core/src/css/variables.css
@@ -14,6 +14,7 @@
   --channelAColor: #e35a59;
   --channelBColor: #24965c;
   --errorTextColor: #ff4444;
+  --warningTextColor: #ffaa00;
   --dangerColor: rgb(207, 23, 23);
   --dangerColorHover: rgb(166, 30, 30);
   --transitionTime: 0.2s;

--- a/packages/ui-core/src/css/variables.css
+++ b/packages/ui-core/src/css/variables.css
@@ -13,6 +13,7 @@
   --actionColor2Hover: rgb(12, 92, 9);
   --channelAColor: #e35a59;
   --channelBColor: #24965c;
+  --errorTextColor: #ff4444;
   --dangerColor: rgb(207, 23, 23);
   --dangerColorHover: rgb(166, 30, 30);
   --transitionTime: 0.2s;


### PR DESCRIPTION
When a sketch fails to build (e.g. some fatal syntax error or fails to import some module), Hedron now displays a dialog showing the build error. This has caught me out too many times recently and was getting annoying having to check the console to see what was wrong.

Fixes #596 

<img width="1164" height="883" alt="Screenshot 2026-02-05 at 14 19 57" src="https://github.com/user-attachments/assets/a38f7c7c-6431-4c20-a33c-d65258b1952e" />
