### PR TITLE
LFO Input fix

### DIFF
--- a/packages/lfo-input/src/LFOInput.ts
+++ b/packages/lfo-input/src/LFOInput.ts
@@ -181,6 +181,11 @@ export class LFOInput implements IPlugin {
 
     const tick = () => {
       requestAnimationFrame(() => {
+        if (!clock.isRunning) {
+          tick()
+          return
+        }
+
         const storeState = store.getState()
         handleEachInput<typeof this.optionNodesConfig>(
           storeState,


### PR DESCRIPTION
This PR fixes the following reproduceable bug:

1. add an LFO to a param
2. enable the LFO in the input options
3. stop the clock
4. try sliding a param using the slider

You'd expect the slider to work (clock isn't on, so you should be able to affect the value). Instead, the slider moves but it has no effect on the sketch.

We just do an early return if the clock is not running, so no input behaviour happens (this is also probably a small performance boost when the clock is off)