### PR TITLE
webgpu passes: handle reorder

### DIFF
--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -201,6 +201,12 @@ export class HedronEngine {
 
     const removeSketchFromScene = (sketchInstanceId: string) => {
       this.sketchManager.removeSketchFromScene(sketchInstanceId)
+      this.renderer.passesNeedUpdate_webGPU = true
+    }
+
+    const handleReorderedSketches = (sketchInstanceIds: string[]) => {
+      this.sketchManager.reorderSketchesInScene(sketchInstanceIds)
+      this.renderer.passesNeedUpdate_webGPU = true
     }
 
     const handleRemovedNode = (nodeId: string) => {
@@ -212,6 +218,7 @@ export class HedronEngine {
       onSketchAdded: addSketchToScene,
       onSketchRemoved: removeSketchFromScene,
       onNodeRemoved: handleRemovedNode,
+      onSketchesReordered: handleReorderedSketches,
     })
   }
 

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -204,7 +204,7 @@ export class HedronEngine {
       this.renderer.passesNeedUpdate_webGPU = true
     }
 
-    const handleReorderedSketches = (sketchInstanceIds: string[]) => {
+    const reorderSketchesInScene = (sketchInstanceIds: string[]) => {
       this.sketchManager.reorderSketchesInScene(sketchInstanceIds)
       this.renderer.passesNeedUpdate_webGPU = true
     }
@@ -218,7 +218,7 @@ export class HedronEngine {
       onSketchAdded: addSketchToScene,
       onSketchRemoved: removeSketchFromScene,
       onNodeRemoved: handleRemovedNode,
-      onSketchesReordered: handleReorderedSketches,
+      onSketchesReordered: reorderSketchesInScene,
     })
   }
 

--- a/packages/engine/src/HedronEngine/storeListener.ts
+++ b/packages/engine/src/HedronEngine/storeListener.ts
@@ -1,3 +1,4 @@
+import { shallow } from 'zustand/shallow'
 import { EngineStore } from '@store/engineStore'
 
 interface StoreListenerConfig {
@@ -5,6 +6,7 @@ interface StoreListenerConfig {
   onSketchAdded: (instanceId: string, moduleId: string) => void
   onSketchRemoved: (instanceId: string) => void
   onNodeRemoved: (nodeId: string) => void
+  onSketchesReordered: (instanceIds: string[]) => void
 }
 
 export const listenToStore = ({
@@ -12,21 +14,29 @@ export const listenToStore = ({
   onSketchAdded,
   onSketchRemoved,
   onNodeRemoved,
+  onSketchesReordered,
 }: StoreListenerConfig) => {
   const unsubscribeSketches = store.subscribe(
     (state) => state.sketches,
     (sketches, previousSketches) => {
-      Object.keys(previousSketches).forEach((prevId) => {
+      const prevKeys = Object.keys(previousSketches)
+      const newKeys = Object.keys(sketches)
+
+      prevKeys.forEach((prevId) => {
         if (!sketches[prevId]) {
           onSketchRemoved(prevId)
         }
       })
 
-      Object.keys(sketches).forEach((id) => {
+      newKeys.forEach((id) => {
         if (!previousSketches[id]) {
           onSketchAdded(id, sketches[id].moduleId)
         }
       })
+
+      if (!shallow(prevKeys, newKeys)) {
+        onSketchesReordered(newKeys)
+      }
     },
   )
 

--- a/packages/engine/src/world/SketchManager.ts
+++ b/packages/engine/src/world/SketchManager.ts
@@ -110,6 +110,20 @@ export class SketchManager {
     this.sketchInstances.delete(instanceId)
   }
 
+  public reorderSketchesInScene = (sketchInstanceIds: string[]): void => {
+    const oldMap = this.sketchInstances
+    this.sketchInstances = new Map()
+
+    sketchInstanceIds.forEach((id) => {
+      const sketchInstance = oldMap.get(id)
+      if (sketchInstance) {
+        this.sketchInstances.set(id, sketchInstance)
+      } else {
+        console.warn(`Sketch instance with id ${id} not found during reorder.`)
+      }
+    })
+  }
+
   public getSketchInstances = () => {
     return this.sketchInstances
   }


### PR DESCRIPTION
Reordering sketches wasn't updating the actual pass order for webgpu. This fixes that with an extra store listener. 

We don't need this for webgl because we're following a different pattern there, but I'd like to unify this a bit (#623)