### PR TITLE
Camera is now private with a get/set

### DIFF
--- a/packages/engine/src/world/EngineScene.ts
+++ b/packages/engine/src/world/EngineScene.ts
@@ -7,7 +7,20 @@ import { RendererType } from '@HedronEngine/types'
 
 export class EngineScene {
   public scene: Scene
-  public camera: PerspectiveCamera
+  private _camera: PerspectiveCamera
+  public get camera(): PerspectiveCamera {
+    return this._camera
+  }
+  public set camera(newCamera: PerspectiveCamera) {
+    this._camera = newCamera
+    if (this.rendererType === 'webgpu' && this.renderPass_webGPU?.camera) {
+      this.renderPass_webGPU.camera = newCamera
+      return
+    }
+    if (this.rendererType === 'webgl' && this.renderPass) {
+      this.renderPass.mainCamera = this._camera
+    }
+  }
   public passes: Pass[] | undefined
   public sketches: SketchInstanceMap = new Map()
   private renderPass: RenderPass | undefined
@@ -29,21 +42,21 @@ export class EngineScene {
     this.rendererType = rendererType
     this.onSketchInstanceError = onSketchInstanceError
     this.scene = new Scene()
-    this.camera = new PerspectiveCamera(75, undefined, 0.1, 100000)
-    this.camera.position.z = 5
+    this._camera = new PerspectiveCamera(75, undefined, 0.1, 100000)
+    this._camera.position.z = 5
     this.rendererType = rendererType
 
     if (this.rendererType === 'webgpu') {
-      this.renderPass_webGPU = pass(this.scene, this.camera)
+      this.renderPass_webGPU = pass(this.scene, this._camera)
     } else {
-      this.renderPass = new RenderPass(this.scene, this.camera)
+      this.renderPass = new RenderPass(this.scene, this._camera)
       this.passes = [this.renderPass]
     }
   }
 
   setRatio(ratio: number): void {
-    this.camera.aspect = ratio
-    this.camera.updateProjectionMatrix()
+    this._camera.aspect = ratio
+    this._camera.updateProjectionMatrix()
   }
 
   addPass(pass: Pass): void {


### PR DESCRIPTION
Makes camera a get/set, so that way it can be replaced by sketches (use at your own risk, maybe we move this to it's own plugin at some point).

Needed this to switch between Perspective and Orthographic