### PR TITLE
Inputs on inputs

### DIFF
--- a/apps/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/apps/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -1,3 +1,4 @@
+import { Node } from '@hedron-gl/engine'
 import {
   Button,
   ViewHeader,
@@ -6,20 +7,36 @@ import {
   Panel,
   PanelBody,
   PanelHeader,
+  PanelBreadcrumbs,
   PopoutMenu,
   HedronErrorBoundary,
   useOnSelectNode,
   NodeContainer,
 } from '@hedron-gl/ui-core'
 
-import { Node } from '@hedron-gl/engine'
 import c from './ActiveSketch.module.css'
 import { useActiveSketch } from '@components/hooks/useActiveSketch'
 import { engineStore } from '@renderer/engine'
 import { SketchControls } from '@components/SketchControls/SketchControls'
 import { useGroupedNodes } from '@components/hooks/useGroupedNodes'
 import { useSelectedNode } from '@components/hooks/useSelectedNode'
+import { useNodeBreadcrumbs } from '@components/hooks/useNodeBreadcrumbs'
 import { SelectedNode } from '@components/SelectedNode/SelectedNode'
+
+const SelectedNodePanel = ({ node, onClose }: { node: Node; onClose: () => void }) => {
+  const breadcrumbs = useNodeBreadcrumbs(node.id)
+
+  return (
+    <Panel snugPosition="bottom" spacing="slim" width="full" className={c.bottomPanel}>
+      <PanelHeader iconName={paramIcon} buttonOnClick={onClose}>
+        <PanelBreadcrumbs items={breadcrumbs} />
+      </PanelHeader>
+      <PanelBody>
+        <SelectedNode />
+      </PanelBody>
+    </Panel>
+  )
+}
 
 export const ActiveSketch = () => {
   const activeSketch = useActiveSketch()
@@ -69,16 +86,7 @@ export const ActiveSketch = () => {
           />
         </div>
 
-        {selectedNode && (
-          <Panel snugPosition="bottom" spacing="slim" width="full" className={c.bottomPanel}>
-            <PanelHeader iconName={paramIcon} buttonOnClick={closeSelectedNodePanel}>
-              {selectedNode.title}
-            </PanelHeader>
-            <PanelBody>
-              <SelectedNode />
-            </PanelBody>
-          </Panel>
-        )}
+        {selectedNode && <SelectedNodePanel node={selectedNode} onClose={closeSelectedNodePanel} />}
       </HedronErrorBoundary>
     </div>
   )

--- a/apps/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
+++ b/apps/desktop/src/renderer/components/ActiveSketch/ActiveSketch.tsx
@@ -8,7 +8,6 @@ import {
   PanelHeader,
   PopoutMenu,
   HedronErrorBoundary,
-  useAppStore,
   useOnSelectNode,
   NodeContainer,
 } from '@hedron-gl/ui-core'
@@ -21,18 +20,6 @@ import { SketchControls } from '@components/SketchControls/SketchControls'
 import { useGroupedNodes } from '@components/hooks/useGroupedNodes'
 import { useSelectedNode } from '@components/hooks/useSelectedNode'
 import { SelectedNode } from '@components/SelectedNode/SelectedNode'
-
-interface ControlItemProps {
-  node: Node
-  sketchId: string
-}
-
-const ControlItem = ({ node, sketchId }: ControlItemProps) => {
-  const isActive = useAppStore((state) => state.selectedNodes[sketchId] === node.id)
-  const onSelectNode = useOnSelectNode(sketchId, node.id)
-
-  return <NodeContainer onClick={onSelectNode} nodeId={node.id} isActive={isActive} />
-}
 
 export const ActiveSketch = () => {
   const activeSketch = useActiveSketch()
@@ -78,7 +65,7 @@ export const ActiveSketch = () => {
           <SketchControls
             sketchId={activeSketch.id}
             nodeGroups={nodeGroups}
-            ControlItem={ControlItem}
+            ControlItem={({ node }) => <NodeContainer nodeId={node.id} />}
           />
         </div>
 

--- a/apps/desktop/src/renderer/components/hooks/useNodeBreadcrumbs.ts
+++ b/apps/desktop/src/renderer/components/hooks/useNodeBreadcrumbs.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import { BreadcrumbItem, useEngineStore } from '@hedron-gl/ui-core'
+import { Node } from '@hedron-gl/engine'
+import { useAppStore } from '@renderer/appStore'
+import { useActiveSketch } from '@components/hooks/useActiveSketch'
+
+interface BreadcrumbData {
+  label: string
+  id: string
+  isSelectable: boolean
+}
+
+export const useNodeBreadcrumbs = (nodeId: string): BreadcrumbItem[] => {
+  const activeSketch = useActiveSketch()
+  const selectNode = useAppStore((state) => state.setSelectedNode)
+
+  const nodes = useEngineStore((state) => state.nodes)
+
+  const data = useMemo(() => {
+    const breadcrumbs: BreadcrumbData[] = []
+    let currentId: string | null = nodeId
+
+    while (currentId) {
+      const node: Node | undefined = nodes[currentId]
+      if (!node) break
+      breadcrumbs.unshift({
+        label: node.title,
+        id: node.id,
+        isSelectable: node.nodeType === 'param' || node.nodeType === 'shot',
+      })
+      currentId = node.parentId
+    }
+
+    return breadcrumbs
+  }, [nodes, nodeId])
+
+  return useMemo(
+    () =>
+      data.map((item, i) => ({
+        label: item.label,
+        id: item.id,
+        onClick:
+          item.isSelectable && activeSketch && i < data.length - 1
+            ? () => selectNode(activeSketch.id, item.id)
+            : undefined,
+      })),
+    [data, activeSketch, selectNode],
+  )
+}

--- a/packages/ui-core/src/components/Button/Button.module.css
+++ b/packages/ui-core/src/components/Button/Button.module.css
@@ -7,6 +7,7 @@
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   transition: var(--transitionTime);
+  text-shadow: var(--textShadow);
   cursor: pointer;
   font-size: 0.8rem;
   font-family: inherit;

--- a/packages/ui-core/src/components/NodeControl/NodeControl.module.css
+++ b/packages/ui-core/src/components/NodeControl/NodeControl.module.css
@@ -24,23 +24,42 @@
 
 .main {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .inner {
   height: 26px;
-  width: 50%;
+  width: 100%;
+}
+
+.info {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.inputCount {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 9px;
+  opacity: 0.5;
+  white-space: nowrap;
+}
+
+.inputCountIcon {
+  font-size: 12px;
 }
 
 .title {
-  width: 50%;
-  border-bottom: 1px dotted var(--lineColor1);
+  flex: 1;
+  min-width: 0;
   padding: 3px;
   display: flex;
-  align-items: flex-start;
-  height: 26px;
-  margin-right: 0.25rem;
+  justify-content: space-between;
+  height: auto;
+  width: 100%;
   letter-spacing: 1px;
   line-height: 100%;
   font-size: 9px;
@@ -51,23 +70,5 @@
 
   &:global(.light) {
     border-color: var(--lineColor2);
-  }
-}
-
-.vertical {
-  .main {
-    flex-direction: column;
-  }
-
-  .title {
-    border-bottom: 0;
-    margin-right: 0;
-    margin-bottom: 0.25rem;
-    height: auto;
-    width: 100%;
-  }
-
-  .inner {
-    width: 100%;
   }
 }

--- a/packages/ui-core/src/components/NodeControl/NodeControl.tsx
+++ b/packages/ui-core/src/components/NodeControl/NodeControl.tsx
@@ -5,20 +5,15 @@ import {
   useWasMouseDownOnInnerContext,
   useMouseDownOnInner,
 } from './wasMouseDownOnInner'
+import { Icon, inputIcon } from '@components/Icon/Icon'
 
 export interface NodeControlProps {
   isActive?: boolean
   children: React.ReactNode
   onClick?: () => void
-  layout?: 'horizontal' | 'vertical'
 }
 
-export const NodeControl = ({
-  isActive,
-  children,
-  onClick,
-  layout = 'horizontal',
-}: NodeControlProps) => {
+export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) => {
   const wasMouseDownOnInner = useWasMouseDownOnInnerContext()
 
   const handleClick = useCallback(() => {
@@ -30,7 +25,7 @@ export const NodeControl = ({
 
   return (
     <MouseDownContext.Provider value={wasMouseDownOnInner}>
-      <div onClick={handleClick} className={`${c.wrapper} ${isActive && 'active'} ${c[layout]}`}>
+      <div onClick={handleClick} className={`${c.wrapper} ${isActive && 'active'}`}>
         {children}
       </div>
     </MouseDownContext.Provider>
@@ -52,6 +47,28 @@ export interface NodeControlTitleProps {
 export const NodeControlTitle = ({ children }: NodeControlTitleProps) => (
   <div className={c.title}>{children}</div>
 )
+
+export interface NodeControlInfoProps {
+  children: React.ReactNode
+}
+
+export const NodeControlInfo = ({ children }: NodeControlInfoProps) => (
+  <div className={c.info}>{children}</div>
+)
+
+export interface NodeControlInputCountProps {
+  inputCount: number
+}
+
+export const NodeControlInputCount = ({ inputCount }: NodeControlInputCountProps) => {
+  if (inputCount === 0) return null
+  return (
+    <div className={c.inputCount}>
+      <Icon name={inputIcon} className={c.inputCountIcon} />
+      {inputCount}
+    </div>
+  )
+}
 
 export interface NodeControlInnerProps {
   children: React.ReactNode

--- a/packages/ui-core/src/components/Panel/Panel.module.css
+++ b/packages/ui-core/src/components/Panel/Panel.module.css
@@ -35,6 +35,12 @@
   }
 }
 
+.headerTitle {
+  font-size: 1rem;
+  font-weight: 500;
+  overflow: auto;
+}
+
 .subHeader {
   display: flex;
   flex: 1;
@@ -79,6 +85,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .breadcrumbClickable {

--- a/packages/ui-core/src/components/Panel/Panel.module.css
+++ b/packages/ui-core/src/components/Panel/Panel.module.css
@@ -68,6 +68,29 @@
   margin-left: auto;
 }
 
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--gapSmall);
+  overflow: hidden;
+}
+
+.breadcrumbItem {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breadcrumbClickable {
+  cursor: pointer;
+  text-decoration: dotted underline;
+}
+
+.breadcrumbSeparator {
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
 .slim {
   .body,
   .header {

--- a/packages/ui-core/src/components/Panel/Panel.module.css
+++ b/packages/ui-core/src/components/Panel/Panel.module.css
@@ -83,7 +83,8 @@
 
 .breadcrumbClickable {
   cursor: pointer;
-  text-decoration: dotted underline;
+  text-decoration: dotted underline 1px;
+  text-underline-offset: 2px;
 }
 
 .breadcrumbSeparator {

--- a/packages/ui-core/src/components/Panel/Panel.tsx
+++ b/packages/ui-core/src/components/Panel/Panel.tsx
@@ -49,14 +49,14 @@ export const PanelHeader = ({
   buttonIcon = 'close',
   buttonOnClick,
 }: PanelHeaderProps) => (
-  <div className={c.header}>
+  <header className={c.header}>
     {iconName && <Icon name={iconName} className={c.icon} />}
-    <h2>{children}</h2>
+    <div className={c.headerTitle}>{children}</div>
 
     {buttonOnClick && (
       <Button className={c.button} iconName={buttonIcon} type="ghost" onClick={buttonOnClick} />
     )}
-  </div>
+  </header>
 )
 
 export interface BreadcrumbItem {
@@ -70,19 +70,20 @@ export interface PanelBreadcrumbsProps {
 }
 
 export const PanelBreadcrumbs = ({ items }: PanelBreadcrumbsProps) => (
-  <div className={c.breadcrumbs}>
+  <nav className={c.breadcrumbs} aria-label="Breadcrumbs">
     {items.map((item, i) => (
       <React.Fragment key={item.id}>
         {i > 0 && <span className={c.breadcrumbSeparator}>/</span>}
-        <span
-          className={`${c.breadcrumbItem} ${item.onClick ? c.breadcrumbClickable : ''}`}
-          onClick={item.onClick}
-        >
-          {item.label}
-        </span>
+        {item.onClick ? (
+          <button className={`${c.breadcrumbItem} ${c.breadcrumbClickable}`} onClick={item.onClick}>
+            {item.label}
+          </button>
+        ) : (
+          <span className={c.breadcrumbItem}>{item.label}</span>
+        )}
       </React.Fragment>
     ))}
-  </div>
+  </nav>
 )
 
 export const PanelSubHeader = ({

--- a/packages/ui-core/src/components/Panel/Panel.tsx
+++ b/packages/ui-core/src/components/Panel/Panel.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import c from './Panel.module.css'
 import { Button } from '@components/Button/Button'
 import { Icon, IconName } from '@components/Icon/Icon'
@@ -55,6 +56,32 @@ export const PanelHeader = ({
     {buttonOnClick && (
       <Button className={c.button} iconName={buttonIcon} type="ghost" onClick={buttonOnClick} />
     )}
+  </div>
+)
+
+export interface BreadcrumbItem {
+  label: string
+  id: string
+  onClick?: () => void
+}
+
+export interface PanelBreadcrumbsProps {
+  items: BreadcrumbItem[]
+}
+
+export const PanelBreadcrumbs = ({ items }: PanelBreadcrumbsProps) => (
+  <div className={c.breadcrumbs}>
+    {items.map((item, i) => (
+      <React.Fragment key={item.id}>
+        {i > 0 && <span className={c.breadcrumbSeparator}>/</span>}
+        <span
+          className={`${c.breadcrumbItem} ${item.onClick ? c.breadcrumbClickable : ''}`}
+          onClick={item.onClick}
+        >
+          {item.label}
+        </span>
+      </React.Fragment>
+    ))}
   </div>
 )
 

--- a/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
+++ b/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
@@ -13,10 +13,12 @@ import {
   NodeControl,
   NodeControlInner,
   NodeControlMain,
-  NodeControlProps,
   NodeControlTitle,
+  NodeControlInfo,
+  NodeControlInputCount,
 } from '@components/NodeControl/NodeControl'
 import { useEngineStore } from '@hooks/storeHooks'
+import { useInputCount } from '@hooks/useInputCount'
 
 const getInputElement = (node: Exclude<Node, Input>) => {
   if (node.nodeType === 'shot') {
@@ -47,14 +49,13 @@ export const NodeContainer = ({
   onClick,
   isActive,
   nodeId,
-  layout,
 }: {
   onClick?: (nodeId: string) => void
   isActive?: boolean
   nodeId: string
-  layout?: NodeControlProps['layout']
 }) => {
   const node = useEngineStore((state) => state.nodes[nodeId])
+  const inputCount = useInputCount(nodeId)
 
   const _onClick = useCallback(() => {
     onClick?.(nodeId)
@@ -69,9 +70,12 @@ export const NodeContainer = ({
   }
 
   return (
-    <NodeControl key={node.key} onClick={_onClick} isActive={isActive} layout={layout}>
+    <NodeControl key={node.key} onClick={_onClick} isActive={isActive}>
       <NodeControlMain>
-        <NodeControlTitle>{node.title}</NodeControlTitle>
+        <NodeControlInfo>
+          <NodeControlTitle>{node.title}</NodeControlTitle>
+          <NodeControlInputCount inputCount={inputCount} />
+        </NodeControlInfo>
         <NodeControlInner>{getInputElement(node)}</NodeControlInner>
       </NodeControlMain>
     </NodeControl>

--- a/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
+++ b/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
@@ -1,5 +1,4 @@
 import { Input, Node } from '@hedron-gl/engine'
-import { useCallback } from 'react'
 import { ParamNumber } from './ParamNumber/ParamNumber'
 import { ParamBoolean } from './ParamBoolean/ParamBoolean'
 import { ParamEnum } from './ParamEnum/ParamEnum'
@@ -17,8 +16,9 @@ import {
   NodeControlInfo,
   NodeControlInputCount,
 } from '@components/NodeControl/NodeControl'
-import { useEngineStore } from '@hooks/storeHooks'
+import { useEngineStore, useAppStore } from '@hooks/storeHooks'
 import { useInputCount } from '@hooks/useInputCount'
+import { useOnSelectNode } from '@hooks/useOnSelectNode'
 
 const getInputElement = (node: Exclude<Node, Input>) => {
   if (node.nodeType === 'shot') {
@@ -45,21 +45,14 @@ const getInputElement = (node: Exclude<Node, Input>) => {
   }
 }
 
-export const NodeContainer = ({
-  onClick,
-  isActive,
-  nodeId,
-}: {
-  onClick?: (nodeId: string) => void
-  isActive?: boolean
-  nodeId: string
-}) => {
+export const NodeContainer = ({ nodeId }: { nodeId: string }) => {
   const node = useEngineStore((state) => state.nodes[nodeId])
   const inputCount = useInputCount(nodeId)
-
-  const _onClick = useCallback(() => {
-    onClick?.(nodeId)
-  }, [nodeId, onClick])
+  const activeSketchId = useAppStore((state) => state.activeSketchId)
+  const isActive = useAppStore((state) =>
+    activeSketchId ? state.selectedNodes[activeSketchId] === nodeId : false,
+  )
+  const onSelectNode = useOnSelectNode(activeSketchId ?? '', nodeId)
 
   if (!node) {
     return <i>Node with id {nodeId} not found</i>
@@ -70,7 +63,7 @@ export const NodeContainer = ({
   }
 
   return (
-    <NodeControl key={node.key} onClick={_onClick} isActive={isActive}>
+    <NodeControl key={node.key} onClick={onSelectNode} isActive={isActive}>
       <NodeControlMain>
         <NodeControlInfo>
           <NodeControlTitle>{node.title}</NodeControlTitle>

--- a/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
+++ b/packages/ui-core/src/containers/NodeContainer/NodeContainer.tsx
@@ -52,7 +52,7 @@ export const NodeContainer = ({ nodeId }: { nodeId: string }) => {
   const isActive = useAppStore((state) =>
     activeSketchId ? state.selectedNodes[activeSketchId] === nodeId : false,
   )
-  const onSelectNode = useOnSelectNode(activeSketchId ?? '', nodeId)
+  const onSelectNode = useOnSelectNode(activeSketchId, nodeId)
 
   if (!node) {
     return <i>Node with id {nodeId} not found</i>

--- a/packages/ui-core/src/css/base.css
+++ b/packages/ui-core/src/css/base.css
@@ -23,9 +23,13 @@ body {
 }
 
 button {
-  text-shadow: var(--textShadow);
   font-family: inherit;
+  text-shadow: inherit;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
   cursor: pointer;
+  padding: 0;
 }
 
 a {

--- a/packages/ui-core/src/hooks/useInputCount.ts
+++ b/packages/ui-core/src/hooks/useInputCount.ts
@@ -1,0 +1,12 @@
+import { useEngineStore } from './storeHooks'
+
+export const useInputCount = (nodeId: string): number => {
+  return useEngineStore((state) => {
+    const node = state.nodes[nodeId]
+    if (!node) return 0
+    return node.childrenIds.filter((childId) => {
+      const child = state.nodes[childId]
+      return child?.nodeType === 'input'
+    }).length
+  })
+}

--- a/packages/ui-core/src/hooks/useOnSelectNode.ts
+++ b/packages/ui-core/src/hooks/useOnSelectNode.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
 import { useAppStore } from '@hooks/storeHooks'
 
-export const useOnSelectNode = (sketchId: string, nodeId: string | null) => {
+export const useOnSelectNode = (sketchId: string | null, nodeId: string | null) => {
   const selectNode = useAppStore((state) => state.setSelectedNode)
 
   const onSelectNode = useCallback(() => {
-    selectNode(sketchId, nodeId)
+    selectNode(sketchId ?? 'NO_ACTIVE_SKETCH', nodeId)
   }, [sketchId, nodeId, selectNode])
 
   return onSelectNode

--- a/packages/ui-core/src/stories/NodeControl.stories.tsx
+++ b/packages/ui-core/src/stories/NodeControl.stories.tsx
@@ -8,6 +8,8 @@ import {
   NodeControlMain,
   NodeControlTitle,
   NodeControlInner,
+  NodeControlInfo,
+  NodeControlInputCount,
 } from '@components/NodeControl/NodeControl'
 
 import { ControlGrid } from '@components/ControlGrid/ControlGrid'
@@ -30,11 +32,10 @@ interface BasicProps {
   title: string
   isActive?: boolean
   color?: 'light'
-  layout?: 'horizontal' | 'vertical'
   onClick: () => void
 }
 
-export const Number = ({ title = 'Short Name', isActive, layout, onClick }: BasicProps) => {
+export const Number = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
@@ -45,7 +46,7 @@ export const Number = ({ title = 'Short Name', isActive, layout, onClick }: Basi
     ref.current!.updateValue(Math.random() * 1)
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -56,34 +57,7 @@ export const Number = ({ title = 'Short Name', isActive, layout, onClick }: Basi
   )
 }
 
-export const NumberVertical = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
-  const ref = useRef<FloatSliderHandle>(null)
-
-  useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
-  }, [])
-
-  useInterval(() => {
-    ref.current!.updateValue(Math.random() * 1)
-  }, 3000)
-  return (
-    <NodeControl isActive={isActive} onClick={onClick} layout="vertical">
-      <NodeControlMain>
-        <NodeControlTitle>{title}</NodeControlTitle>
-        <NodeControlInner>
-          <FloatSlider min={-1} max={1} onValueChange={fn()} ref={ref} />
-        </NodeControlInner>
-      </NodeControlMain>
-    </NodeControl>
-  )
-}
-
-export const NumberMinMaxPositive = ({
-  title = 'Short Name',
-  isActive,
-  layout,
-  onClick,
-}: BasicProps) => {
+export const NumberMinMaxPositive = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
@@ -91,7 +65,7 @@ export const NumberMinMaxPositive = ({
   }, [])
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -102,12 +76,7 @@ export const NumberMinMaxPositive = ({
   )
 }
 
-export const NumberMinMaxNegative = ({
-  title = 'Short Name',
-  isActive,
-  layout,
-  onClick,
-}: BasicProps) => {
+export const NumberMinMaxNegative = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
@@ -115,7 +84,7 @@ export const NumberMinMaxNegative = ({
   }, [])
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -126,7 +95,7 @@ export const NumberMinMaxNegative = ({
   )
 }
 
-export const NumberTextOnly = ({ title = 'Short Name', isActive, layout, onClick }: BasicProps) => {
+export const NumberTextOnly = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<NumberInputHandle>(null)
 
   useEffect(() => {
@@ -138,7 +107,7 @@ export const NumberTextOnly = ({ title = 'Short Name', isActive, layout, onClick
   }, 3000)
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -149,14 +118,14 @@ export const NumberTextOnly = ({ title = 'Short Name', isActive, layout, onClick
   )
 }
 
-export const Boolean = ({ title = 'Boolean Thing', isActive, layout, onClick }: BasicProps) => {
+export const Boolean = ({ title = 'Boolean Thing', isActive, onClick }: BasicProps) => {
   const ref = useRef<BooleanToggleHandle>(null)
 
   useInterval(() => {
     ref.current!.setChecked(Math.random() > 0.5)
   }, 3000)
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -167,7 +136,7 @@ export const Boolean = ({ title = 'Boolean Thing', isActive, layout, onClick }: 
   )
 }
 
-export const Color = ({ title = 'Color Picker', isActive, layout, onClick }: BasicProps) => {
+export const Color = ({ title = 'Color Picker', isActive, onClick }: BasicProps) => {
   const ref = useRef<ColorPickerHandle>(null)
 
   useInterval(() => {
@@ -175,7 +144,7 @@ export const Color = ({ title = 'Color Picker', isActive, layout, onClick }: Bas
   }, 3000)
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -192,7 +161,7 @@ const options = [
   { value: 'option3', label: 'MyExtraLongOptionNameWithNoSpacesWow' },
 ]
 
-export const Enum = ({ title = 'Enum Dropdown', isActive, layout, onClick }: BasicProps) => {
+export const Enum = ({ title = 'Enum Dropdown', isActive, onClick }: BasicProps) => {
   const ref = useRef<EnumDropdownHandle>(null)
 
   useInterval(() => {
@@ -200,7 +169,7 @@ export const Enum = ({ title = 'Enum Dropdown', isActive, layout, onClick }: Bas
   }, 3000)
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -211,7 +180,7 @@ export const Enum = ({ title = 'Enum Dropdown', isActive, layout, onClick }: Bas
   )
 }
 
-export const Trigger = ({ title = 'Trigger Pad', isActive, layout, onClick }: BasicProps) => {
+export const Trigger = ({ title = 'Trigger Pad', isActive, onClick }: BasicProps) => {
   const ref = useRef<TriggerPadHandle>(null)
 
   const onPadClick = () => {
@@ -224,7 +193,7 @@ export const Trigger = ({ title = 'Trigger Pad', isActive, layout, onClick }: Ba
   }, 3000)
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
@@ -251,11 +220,7 @@ const params = [
   ['Trigger Pad', 'trigger'],
 ]
 
-interface ControlGridStoryProps {
-  layout?: 'horizontal' | 'vertical'
-}
-
-export const WithControlGrid = ({ layout }: ControlGridStoryProps) => {
+export const WithControlGrid = () => {
   const [activeId, setActiveId] = useState(0)
 
   return (
@@ -267,7 +232,6 @@ export const WithControlGrid = ({ layout }: ControlGridStoryProps) => {
               key={i}
               title={title}
               isActive={activeId === i}
-              layout={layout}
               onClick={() => setActiveId(i)}
             />
           )}
@@ -276,34 +240,20 @@ export const WithControlGrid = ({ layout }: ControlGridStoryProps) => {
               key={i}
               title={title}
               isActive={activeId === i}
-              layout={layout}
               onClick={() => setActiveId(i)}
             />
           )}
           {type === 'color' && (
-            <Color
-              key={i}
-              title={title}
-              isActive={activeId === i}
-              layout={layout}
-              onClick={() => setActiveId(i)}
-            />
+            <Color key={i} title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'enum' && (
-            <Enum
-              key={i}
-              title={title}
-              isActive={activeId === i}
-              layout={layout}
-              onClick={() => setActiveId(i)}
-            />
+            <Enum key={i} title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'trigger' && (
             <Trigger
               key={i}
               title={title}
               isActive={activeId === i}
-              layout={layout}
               onClick={() => setActiveId(i)}
             />
           )}
@@ -312,8 +262,6 @@ export const WithControlGrid = ({ layout }: ControlGridStoryProps) => {
     </ControlGrid>
   )
 }
-
-export const WithControlGridVertical = () => <WithControlGrid layout="vertical" />
 
 export const GridOnPanel = () => (
   <Panel spacing="slim">
@@ -324,7 +272,7 @@ export const GridOnPanel = () => (
   </Panel>
 )
 
-export const NumberReversed = ({ title = 'Short Name', isActive, layout, onClick }: BasicProps) => {
+export const NumberReversed = ({ title = 'Short Name', isActive, onClick }: BasicProps) => {
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
@@ -332,11 +280,73 @@ export const NumberReversed = ({ title = 'Short Name', isActive, layout, onClick
   }, [])
 
   return (
-    <NodeControl isActive={isActive} onClick={onClick} layout={layout}>
+    <NodeControl isActive={isActive} onClick={onClick}>
       <NodeControlMain>
         <NodeControlTitle>{title}</NodeControlTitle>
         <NodeControlInner>
           <FloatSlider min={10} max={-10} onValueChange={fn()} ref={ref} />
+        </NodeControlInner>
+      </NodeControlMain>
+    </NodeControl>
+  )
+}
+
+export const NumberWithInputCount = ({ title = 'Brightness', isActive, onClick }: BasicProps) => {
+  const ref = useRef<FloatSliderHandle>(null)
+
+  useEffect(() => {
+    ref.current?.updateValue(Math.random() * 1)
+  }, [])
+
+  return (
+    <NodeControl isActive={isActive} onClick={onClick}>
+      <NodeControlMain>
+        <NodeControlInfo>
+          <NodeControlTitle>{title}</NodeControlTitle>
+          <NodeControlInputCount inputCount={2} />
+        </NodeControlInfo>
+        <NodeControlInner>
+          <FloatSlider min={0} max={1} onValueChange={fn()} ref={ref} />
+        </NodeControlInner>
+      </NodeControlMain>
+    </NodeControl>
+  )
+}
+
+export const BooleanWithInputCount = ({ title = 'Enabled', isActive, onClick }: BasicProps) => {
+  const ref = useRef<BooleanToggleHandle>(null)
+
+  return (
+    <NodeControl isActive={isActive} onClick={onClick}>
+      <NodeControlMain>
+        <NodeControlInfo>
+          <NodeControlTitle>{title}</NodeControlTitle>
+          <NodeControlInputCount inputCount={1} />
+        </NodeControlInfo>
+        <NodeControlInner>
+          <BooleanToggle onValueChange={fn()} ref={ref} />
+        </NodeControlInner>
+      </NodeControlMain>
+    </NodeControl>
+  )
+}
+
+export const WithInputCountZero = ({ title = 'No Inputs', isActive, onClick }: BasicProps) => {
+  const ref = useRef<FloatSliderHandle>(null)
+
+  useEffect(() => {
+    ref.current?.updateValue(0.5)
+  }, [])
+
+  return (
+    <NodeControl isActive={isActive} onClick={onClick}>
+      <NodeControlMain>
+        <NodeControlInfo>
+          <NodeControlTitle>{title}</NodeControlTitle>
+          <NodeControlInputCount inputCount={0} />
+        </NodeControlInfo>
+        <NodeControlInner>
+          <FloatSlider min={0} max={1} onValueChange={fn()} ref={ref} />
         </NodeControlInner>
       </NodeControlMain>
     </NodeControl>

--- a/packages/ui-core/src/stories/NodeControl.stories.tsx
+++ b/packages/ui-core/src/stories/NodeControl.stories.tsx
@@ -39,11 +39,11 @@ export const Number = ({ title = 'Short Name', isActive, onClick }: BasicProps) 
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   useInterval(() => {
-    ref.current!.updateValue(Math.random() * 1)
+    ref.current!.updateValue(Math.random())
   }, 3000)
   return (
     <NodeControl isActive={isActive} onClick={onClick}>
@@ -61,7 +61,7 @@ export const NumberMinMaxPositive = ({ title = 'Short Name', isActive, onClick }
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   return (
@@ -80,7 +80,7 @@ export const NumberMinMaxNegative = ({ title = 'Short Name', isActive, onClick }
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   return (
@@ -99,11 +99,11 @@ export const NumberTextOnly = ({ title = 'Short Name', isActive, onClick }: Basi
   const ref = useRef<NumberInputHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   useInterval(() => {
-    ref.current!.updateValue(Math.random() * 1)
+    ref.current!.updateValue(Math.random())
   }, 3000)
 
   return (
@@ -261,7 +261,7 @@ export const NumberReversed = ({ title = 'Short Name', isActive, onClick }: Basi
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   return (
@@ -280,7 +280,7 @@ export const NumberWithInputCount = ({ title = 'Brightness', isActive, onClick }
   const ref = useRef<FloatSliderHandle>(null)
 
   useEffect(() => {
-    ref.current?.updateValue(Math.random() * 1)
+    ref.current?.updateValue(Math.random())
   }, [])
 
   return (

--- a/packages/ui-core/src/stories/NodeControl.stories.tsx
+++ b/packages/ui-core/src/stories/NodeControl.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react'
 import { fn } from '@storybook/test'
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useInterval } from 'usehooks-ts'
 import { EnumDropdown, EnumDropdownHandle } from '@components/EnumDropdown/EnumDropdown'
 import {
@@ -226,38 +226,23 @@ export const WithControlGrid = () => {
   return (
     <ControlGrid>
       {params.map(([title, type], i) => (
-        <>
+        <Fragment key={i}>
           {type === 'number' && (
-            <Number
-              key={i}
-              title={title}
-              isActive={activeId === i}
-              onClick={() => setActiveId(i)}
-            />
+            <Number title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'boolean' && (
-            <Boolean
-              key={i}
-              title={title}
-              isActive={activeId === i}
-              onClick={() => setActiveId(i)}
-            />
+            <Boolean title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'color' && (
-            <Color key={i} title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
+            <Color title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'enum' && (
-            <Enum key={i} title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
+            <Enum title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
           {type === 'trigger' && (
-            <Trigger
-              key={i}
-              title={title}
-              isActive={activeId === i}
-              onClick={() => setActiveId(i)}
-            />
+            <Trigger title={title} isActive={activeId === i} onClick={() => setActiveId(i)} />
           )}
-        </>
+        </Fragment>
       ))}
     </ControlGrid>
   )

--- a/packages/ui-core/src/stories/Panel.stories.tsx
+++ b/packages/ui-core/src/stories/Panel.stories.tsx
@@ -9,6 +9,7 @@ import {
   PanelBody,
   PanelHeader,
   PanelSubHeader,
+  PanelBreadcrumbs,
 } from '@components/Panel/Panel'
 import { Button } from '@components/Button/Button'
 
@@ -214,6 +215,47 @@ export const BottomPanel: Story = {
               <Icon name="delete" />
             </Button>
           </PanelSubHeader>
+          <WithControlGrid />
+        </PanelBody>
+      </Panel>
+    )
+  },
+}
+
+export const WithBreadcrumbs: Story = {
+  render: () => {
+    return (
+      <Panel>
+        <PanelHeader iconName="tune" buttonOnClick={fn()}>
+          <PanelBreadcrumbs
+            items={[
+              { label: 'Logo', id: 'sketch-1', onClick: fn() },
+              { label: 'Speed', id: 'param-1' },
+            ]}
+          />
+        </PanelHeader>
+        <PanelBody>
+          <p>Panel content with breadcrumbs in the header.</p>
+        </PanelBody>
+      </Panel>
+    )
+  },
+}
+
+export const WithClickableBreadcrumbs: Story = {
+  render: () => {
+    return (
+      <Panel snugPosition="bottom" spacing="slim" width="full">
+        <PanelHeader iconName="tune" buttonOnClick={fn()}>
+          <PanelBreadcrumbs
+            items={[
+              { label: 'My Awesome Sketch', id: 'sketch-1', onClick: fn() },
+              { label: 'Material Settings', id: 'group-1', onClick: fn() },
+              { label: 'Diffuse Color', id: 'param-1' },
+            ]}
+          />
+        </PanelHeader>
+        <PanelBody>
           <WithControlGrid />
         </PanelBody>
       </Panel>

--- a/packages/ui-core/src/stories/Panel.stories.tsx
+++ b/packages/ui-core/src/stories/Panel.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
 
 import { fn } from '@storybook/test'
 import { WithControlGrid } from './NodeControl.stories'
@@ -12,6 +12,20 @@ import {
   PanelBreadcrumbs,
 } from '@components/Panel/Panel'
 import { Button } from '@components/Button/Button'
+
+const bottomDecorator: Decorator = (Story) => {
+  return (
+    <div
+      style={{
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'flex-end',
+      }}
+    >
+      <Story />
+    </div>
+  )
+}
 
 const meta = {
   title: 'Panel',
@@ -185,21 +199,7 @@ export const BottomPanel: Story = {
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [
-    (Story) => {
-      return (
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            alignItems: 'flex-end',
-          }}
-        >
-          <Story />
-        </div>
-      )
-    },
-  ],
+  decorators: [bottomDecorator],
   render: () => {
     return (
       <Panel snugPosition="bottom" spacing="slim" width="full">
@@ -222,10 +222,14 @@ export const BottomPanel: Story = {
   },
 }
 
-export const WithBreadcrumbs: Story = {
+export const BottomPanelWithBreadcrumbs: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [bottomDecorator],
   render: () => {
     return (
-      <Panel>
+      <Panel snugPosition="bottom" spacing="slim" width="full">
         <PanelHeader iconName="tune" buttonOnClick={fn()}>
           <PanelBreadcrumbs
             items={[
@@ -243,6 +247,10 @@ export const WithBreadcrumbs: Story = {
 }
 
 export const WithClickableBreadcrumbs: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [bottomDecorator],
   render: () => {
     return (
       <Panel snugPosition="bottom" spacing="slim" width="full">


### PR DESCRIPTION
- Node control layout is always now vertical
- Node controls now display input count
- Can now open any node in the selected node panel
- Selected node for sketch now has breadcrumbs for navigating back up

@cale-bradbury you cool with the design change with everything being vertical like this? It made sense to squeeze that input count in and has the benefit of wider sliders, but I'm not entirely sure I love it 😅 We can always change it later...

https://github.com/user-attachments/assets/d9f2f0c5-d67b-4b99-8be2-6f1ceb8b3752

