### PR TITLE
Timeline tied to clock

### DIFF
--- a/apps/clock-test-app/src/App.tsx
+++ b/apps/clock-test-app/src/App.tsx
@@ -106,7 +106,7 @@ function App() {
     clockRef.current?.sendTempoTap()
   }
 
-  const onDeltaSliderChange = () => {
+  const onDeltaSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     clockRef.current!.beatDelta = Number(e.target.value)
   }
 

--- a/apps/clock-test-app/src/App.tsx
+++ b/apps/clock-test-app/src/App.tsx
@@ -106,7 +106,7 @@ function App() {
     clockRef.current?.sendTempoTap()
   }
 
-  const onDeltaSliderChange = (e) => {
+  const onDeltaSliderChange = () => {
     clockRef.current!.beatDelta = Number(e.target.value)
   }
 

--- a/apps/clock-test-app/src/App.tsx
+++ b/apps/clock-test-app/src/App.tsx
@@ -106,6 +106,10 @@ function App() {
     clockRef.current?.sendTempoTap()
   }
 
+  const onDeltaSliderChange = (e) => {
+    clockRef.current!.beatDelta = Number(e.target.value)
+  }
+
   return (
     <>
       <section>
@@ -146,6 +150,9 @@ function App() {
             </div>
           </form>
         </div>
+      </section>
+      <section className="grid">
+        <input type="range" min={0} max={64} step={0.001} onChange={onDeltaSliderChange}></input>
       </section>
       <section className="grid">
         <div className="circle"></div>

--- a/packages/clock/src/index.ts
+++ b/packages/clock/src/index.ts
@@ -104,6 +104,14 @@ export class Clock {
   }
 
   /**
+   * Sets the beat delta for external manual control (e.g. timelines)
+   * @param value The new beat delta
+   */
+  set beatDelta(value: number) {
+    this._beatDelta = value
+  }
+
+  /**
    * Gets the current beat count.
    * @returns The current beat count
    */

--- a/packages/clock/src/index.ts
+++ b/packages/clock/src/index.ts
@@ -56,15 +56,19 @@ export class Clock {
       this._beatDelta += deltaInc
       this._beatPulseComparisonDelta += deltaInc
 
-      const newBeatCount = Math.floor(this._beatDelta % 4)
-      if (newBeatCount !== this._beatCount) {
-        this._onNewBeat?.(newBeatCount)
-        this._beatCount = newBeatCount
-      }
+      this.updateBeatCount()
 
       requestAnimationFrame(this.tick)
 
       this._lastTimestamp = timestamp
+    }
+  }
+
+  private updateBeatCount = () => {
+    const newBeatCount = Math.floor(this._beatDelta % 4)
+    if (newBeatCount !== this._beatCount) {
+      this._onNewBeat?.(newBeatCount)
+      this._beatCount = newBeatCount
     }
   }
 
@@ -109,6 +113,15 @@ export class Clock {
    */
   set beatDelta(value: number) {
     this._beatDelta = value
+    this.updateBeatCount()
+  }
+
+  /**
+   * Sets the beat delta using a millisecond value, factoring in the current BPM
+   * @param deltaMs The new beat delta in milliseconds
+   */
+  set beatDeltaMs(deltaMs: number) {
+    this.beatDelta = (deltaMs / MS_IN_MINUTE) * this._bpm
   }
 
   /**

--- a/packages/lfo-input/src/LFOInput.ts
+++ b/packages/lfo-input/src/LFOInput.ts
@@ -128,6 +128,8 @@ export class LFOInput implements IPlugin {
 
   private inputLatches: Record<string, boolean> = {}
 
+  private lastClockBeatDelta: number = -1
+
   private handleShot: ShotHandler = ({ delta, input, engine }) => {
     const val = Math.sin(delta)
 
@@ -188,10 +190,12 @@ export class LFOInput implements IPlugin {
 
     const tick = () => {
       requestAnimationFrame(() => {
-        if (!clock.isRunning) {
+        if (clock.beatDelta === this.lastClockBeatDelta) {
           tick()
           return
         }
+
+        this.lastClockBeatDelta = clock.beatDelta
 
         const storeState = store.getState()
         handleEachInput<typeof this.optionNodesConfig>(

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -36,6 +36,7 @@
     "vite-tsconfig-paths": "^5.1.4"
   },
   "dependencies": {
+    "@hedron-gl/clock": "^1.0.0-alpha.4",
     "@hedron-gl/engine": "^1.0.0-alpha.4",
     "@hedron-gl/ui-core": "^1.0.0-alpha.4"
   },

--- a/packages/timeline/src/TimelineInput.ts
+++ b/packages/timeline/src/TimelineInput.ts
@@ -56,10 +56,13 @@ export class TimelineInput implements IPlugin {
 
     this.timelineManagers.set(
       DEFAULT_TIMELINE_ID,
-      new TimelineManager({
-        durationMs: 60000,
-        tracks: [],
-      }),
+      new TimelineManager(
+        {
+          durationMs: 60000,
+          tracks: [],
+        },
+        engine.clock,
+      ),
     )
 
     this.timelineManagers.forEach((manager, timelineId) => {

--- a/packages/timeline/src/TimelineInput.ts
+++ b/packages/timeline/src/TimelineInput.ts
@@ -5,7 +5,7 @@ import {
   isEqual,
   OptionNodesFromConfigs,
 } from '@hedron-gl/engine'
-import { DEFAULT_TIMELINE_ID } from './constants'
+import { DEFAULT_TIMELINE_ID, TIMELINE_DURATION } from './constants'
 import { TimelineManager } from './TimelineManager'
 import { getTimelineTracks } from './selectors/getTimelineTracks'
 import { TimelineManagerKeyframeTrack } from './types'
@@ -58,7 +58,7 @@ export class TimelineInput implements IPlugin {
       DEFAULT_TIMELINE_ID,
       new TimelineManager(
         {
-          durationMs: 60000,
+          durationMs: TIMELINE_DURATION,
           tracks: [],
         },
         engine.clock,

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -124,10 +124,7 @@ export class TimelineManager {
     this.emitUpdate()
 
     if (this.position >= this.timelineData.durationMs) {
-      this.playing = false
-      this.lastFrameTime = null
-      this.resetKeyframeIndexes()
-      return
+      this.goTo(0)
     }
 
     this.rafId = requestAnimationFrame(this.tick)
@@ -135,11 +132,6 @@ export class TimelineManager {
 
   play() {
     if (this.playing) return
-
-    if (this.position >= this.timelineData.durationMs) {
-      this.position = 0
-      this.resetKeyframeIndexes()
-    }
 
     if (this.clock) {
       this.clock.beatDeltaMs = this.position

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -1,3 +1,4 @@
+import { Clock } from '@hedron-gl/clock'
 import type {
   TimelineManagerData,
   TimelineManagerTrack,
@@ -20,9 +21,11 @@ export class TimelineManager {
   private sortedKeyframesCache: Map<string, Keyframe[]> = new Map()
   private audioCache: Map<string, HTMLAudioElement> = new Map()
   private lastKeyframeIndex: Map<string, number> = new Map()
+  private clock: Clock | null = null
 
-  constructor(timeline: TimelineManagerData) {
+  constructor(timeline: TimelineManagerData, clock?: Clock) {
     this.timelineData = timeline
+    this.clock = clock ?? null
     this.buildCache()
   }
 
@@ -111,6 +114,10 @@ export class TimelineManager {
     if (this.lastFrameTime !== null) {
       const delta = now - this.lastFrameTime
       this.position = Math.min(this.position + delta, this.timelineData.durationMs)
+
+      if (this.clock) {
+        this.clock.beatDeltaMs = this.position
+      }
     }
     this.lastFrameTime = now
 
@@ -128,9 +135,18 @@ export class TimelineManager {
 
   play() {
     if (this.playing) return
+
+    if (this.clock) {
+      this.clock.continue()
+    }
+
     if (this.position >= this.timelineData.durationMs) {
       this.position = 0
       this.resetKeyframeIndexes()
+
+      if (this.clock) {
+        this.clock.beatDeltaMs = 0
+      }
     }
     this.playing = true
     this.lastFrameTime = null
@@ -146,6 +162,11 @@ export class TimelineManager {
   pause() {
     this.playing = false
     this.lastFrameTime = null
+
+    if (this.clock) {
+      this.clock.stop()
+    }
+
     if (this.rafId !== null) {
       cancelAnimationFrame(this.rafId)
       this.rafId = null
@@ -162,6 +183,11 @@ export class TimelineManager {
     this.lastFrameTime = null
     this.resetKeyframeIndexes()
     this.emitUpdate()
+
+    if (this.clock) {
+      console.log(timeMs)
+      this.clock.beatDeltaMs = timeMs
+    }
 
     // Seek audio tracks
     for (const { audio } of this.getAudioTracksWithAudio()) {

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -185,7 +185,6 @@ export class TimelineManager {
     this.emitUpdate()
 
     if (this.clock) {
-      console.log(timeMs)
       this.clock.beatDeltaMs = timeMs
     }
 

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -175,7 +175,7 @@ export class TimelineManager {
     this.emitUpdate()
 
     if (this.clock) {
-      this.clock.beatDeltaMs = timeMs
+      this.clock.beatDeltaMs = this.position
     }
 
     // Seek audio tracks

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -136,18 +136,16 @@ export class TimelineManager {
   play() {
     if (this.playing) return
 
-    if (this.clock) {
-      this.clock.continue()
-    }
-
     if (this.position >= this.timelineData.durationMs) {
       this.position = 0
       this.resetKeyframeIndexes()
-
-      if (this.clock) {
-        this.clock.beatDeltaMs = 0
-      }
     }
+
+    if (this.clock) {
+      this.clock.beatDeltaMs = this.position
+      this.clock.continue()
+    }
+
     this.playing = true
     this.lastFrameTime = null
     this.rafId = requestAnimationFrame(this.tick)

--- a/packages/timeline/src/components/Timeline/Timeline.tsx
+++ b/packages/timeline/src/components/Timeline/Timeline.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import c from './Timeline.module.css'
 import '@hedron-gl/ui-core/base.css'
 import '@hedron-gl/ui-core/fonts.css'
 import { TrackKeyframes } from './TrackKeyframes'
+import { usePlayheadScrub } from './usePlayheadScrub'
 import { TimelineManagerTrack } from '@/types'
 
 export interface TimelineProps {
@@ -29,7 +30,7 @@ export function Timeline({
   onKeyframeInsert,
 }: TimelineProps) {
   const { durationMs, tracks } = timeline
-  const trackAreaRef = useRef<HTMLDivElement>(null)
+  const rulerAreaRef = useRef<HTMLDivElement>(null)
   const [selectedTrack, setSelectedTrack] = useState<string | null>(null)
   const [selectedKeyframe, setSelectedKeyframe] = useState<string | null>(null)
 
@@ -47,21 +48,7 @@ export function Timeline({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [selectedKeyframe, onKeyframeDelete, selectedTrack, playheadPositionMs, onKeyframeInsert])
 
-  const handleTrackClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!trackAreaRef.current || !onPlayheadChange) return
-      const rect = trackAreaRef.current.getBoundingClientRect()
-      const headerWidth = parseFloat(
-        getComputedStyle(trackAreaRef.current).getPropertyValue('--trackHeaderWidth'),
-      )
-      const trackWidth = rect.width - headerWidth
-      const x = e.clientX - rect.left - headerWidth
-      if (x < 0) return
-      const time = (x / trackWidth) * durationMs
-      onPlayheadChange(Math.max(0, Math.min(durationMs, time)))
-    },
-    [durationMs, onPlayheadChange],
-  )
+  usePlayheadScrub(durationMs, rulerAreaRef, onPlayheadChange)
 
   const playheadPercent = (playheadPositionMs / durationMs) * 100
 
@@ -85,8 +72,10 @@ export function Timeline({
           {(playheadPositionMs / 1000).toFixed(1)}s / {durationSec}s
         </span>
       </div>
-      <div className={c.body} ref={trackAreaRef} onClick={handleTrackClick}>
-        <div className={c.ruler}>{rulerMarks}</div>
+      <div className={c.body}>
+        <div className={c.ruler} ref={rulerAreaRef}>
+          {rulerMarks}
+        </div>
         {tracks.map((track) => {
           const isSelected = selectedTrack === track.id
           return (

--- a/packages/timeline/src/components/Timeline/Timeline.tsx
+++ b/packages/timeline/src/components/Timeline/Timeline.tsx
@@ -48,7 +48,7 @@ export function Timeline({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [selectedKeyframe, onKeyframeDelete, selectedTrack, playheadPositionMs, onKeyframeInsert])
 
-  usePlayheadScrub(durationMs, rulerAreaRef, onPlayheadChange)
+  usePlayheadScrub(durationMs, rulerAreaRef, playheadPositionMs, onPlayheadChange)
 
   const playheadPercent = (playheadPositionMs / durationMs) * 100
 

--- a/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
+++ b/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
@@ -4,35 +4,43 @@ import { useCallback, useEffect, useRef } from 'react'
 export const usePlayheadScrub = (
   durationMs: number,
   playheadAreaRef: React.RefObject<HTMLDivElement>,
+  playheadPositionMs: number,
   onPlayheadChange?: (time: number) => void,
 ) => {
   // We need this as a ref for useElementScrub to work properly
   const playheadPositionRef = useRef(0)
 
+  useEffect(() => {
+    playheadPositionRef.current = playheadPositionMs
+  }, [playheadPositionMs])
+
+  const clampTime = useCallback(
+    (time: number) => Math.max(0, Math.min(durationMs, time)),
+    [durationMs],
+  )
+
   const onPlayheadAreaScrub = useCallback(
     ({ x }: { x: number }) => {
-      const newTime = playheadPositionRef.current + x * durationMs
+      const newTime = clampTime(playheadPositionRef.current + x * durationMs)
 
       onPlayheadChange?.(newTime)
       playheadPositionRef.current = newTime
     },
-    [durationMs, onPlayheadChange],
+    [clampTime, durationMs, onPlayheadChange],
   )
 
   const onRulerMouseDown = useCallback(
     (e: MouseEvent) => {
       if (!playheadAreaRef.current || !onPlayheadChange) return
       const rect = playheadAreaRef.current.getBoundingClientRect()
+      if (rect.width <= 0) return
 
-      const x = e.clientX - rect.left
-
-      if (x < 0) return
-
-      const time = (x / rect.width) * durationMs
+      const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left))
+      const time = clampTime((x / rect.width) * durationMs)
       onPlayheadChange(time)
       playheadPositionRef.current = time
     },
-    [durationMs, onPlayheadChange, playheadAreaRef],
+    [clampTime, durationMs, onPlayheadChange, playheadAreaRef],
   )
 
   useEffect(() => {

--- a/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
+++ b/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
@@ -1,0 +1,47 @@
+import { useElementScrub } from '@hedron-gl/ui-core'
+import { useCallback, useEffect, useRef } from 'react'
+
+export const usePlayheadScrub = (
+  durationMs: number,
+  playheadAreaRef: React.RefObject<HTMLDivElement>,
+  onPlayheadChange?: (time: number) => void,
+) => {
+  // We need this as a ref for useElementScrub to work properly
+  const playheadPositionRef = useRef(0)
+
+  const onPlayheadAreaScrub = useCallback(
+    ({ x }: { x: number }) => {
+      const newTime = playheadPositionRef.current + x * durationMs
+
+      onPlayheadChange?.(newTime)
+      playheadPositionRef.current = newTime
+    },
+    [durationMs, onPlayheadChange],
+  )
+
+  const onRulerMouseDown = useCallback(
+    (e: MouseEvent) => {
+      if (!playheadAreaRef.current || !onPlayheadChange) return
+      const rect = playheadAreaRef.current.getBoundingClientRect()
+
+      const x = e.clientX - rect.left
+
+      if (x < 0) return
+
+      const time = (x / rect.width) * durationMs
+      onPlayheadChange(time)
+      playheadPositionRef.current = time
+    },
+    [durationMs, onPlayheadChange, playheadAreaRef],
+  )
+
+  useEffect(() => {
+    const current = playheadAreaRef.current
+    current?.addEventListener('mousedown', onRulerMouseDown)
+    return () => {
+      current?.removeEventListener('mousedown', onRulerMouseDown)
+    }
+  }, [onRulerMouseDown, playheadAreaRef])
+
+  useElementScrub(playheadAreaRef, onPlayheadAreaScrub, 'ew-resize')
+}

--- a/packages/timeline/src/components/TimelineGlobalPanel/useTimelineData.tsx
+++ b/packages/timeline/src/components/TimelineGlobalPanel/useTimelineData.tsx
@@ -2,10 +2,8 @@ import { useMemo } from 'react'
 
 import { useEngineStoreDeepEqual } from '@hedron-gl/ui-core'
 
-import { DEFAULT_TIMELINE_ID } from '@/constants'
+import { DEFAULT_TIMELINE_ID, TIMELINE_DURATION } from '@/constants'
 import { getTimelineTracks } from '@/selectors/getTimelineTracks'
-
-const TIMELINE_DURATION = 10000
 
 export const useTimelineData = () => {
   const tracks = useEngineStoreDeepEqual((state) => getTimelineTracks(state, DEFAULT_TIMELINE_ID))

--- a/packages/timeline/src/constants.ts
+++ b/packages/timeline/src/constants.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_TIMELINE_ID = 'default-timeline'
 
 export const DEFAULT_AUDIO_TRACK_ID = 'default-audio-track'
+
+export const TIMELINE_DURATION = 10000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
 
   packages/timeline:
     dependencies:
+      '@hedron-gl/clock':
+        specifier: ^1.0.0-alpha.4
+        version: link:../clock
       '@hedron-gl/engine':
         specifier: ^1.0.0-alpha.4
         version: link:../engine


### PR DESCRIPTION
Timeline is now tied to the clock. Scrubbing on the timeline playhead moves the clock back and forth, affecting LFOs