### PR TITLE
Timeline: fire shots from keyframes

### DIFF
--- a/packages/timeline/src/TimelineInput.ts
+++ b/packages/timeline/src/TimelineInput.ts
@@ -7,6 +7,7 @@ import {
   OptionNodesFromConfigs,
   isParamVector,
   ParamNode,
+  ParamValue,
   ShotNode,
   isParamVectorComponent,
 } from '@hedron-gl/engine'
@@ -121,14 +122,29 @@ export class TimelineInput implements IPlugin {
           }
 
           const tracks = getKeyframeTracks(allTracks)
-          const changedTargetNodeIds = changedTrackIds.map(
-            (trackId) => tracks.find((track) => track.id === trackId)?.targetNodeId ?? trackId,
-          )
 
-          engine.setMultipleParamValues(
-            changedTargetNodeIds,
-            changedTrackIds.map((trackId) => changed[trackId]),
-          )
+          const paramTargetNodeIds: string[] = []
+          const paramValues: ParamValue[] = []
+
+          for (const trackId of changedTrackIds) {
+            const targetNodeId = tracks.find((track) => track.id === trackId)?.targetNodeId ?? trackId
+            const targetNode = engine.getNode(targetNodeId)
+            const value = changed[trackId]
+
+            if (targetNode?.nodeType === 'shot') {
+              if (value) {
+                engine.fireShot(targetNodeId)
+              }
+              continue
+            }
+
+            paramTargetNodeIds.push(targetNodeId)
+            paramValues.push(value)
+          }
+
+          if (paramTargetNodeIds.length > 0) {
+            engine.setMultipleParamValues(paramTargetNodeIds, paramValues)
+          }
         }
       })
     })

--- a/packages/timeline/src/TimelineInput.ts
+++ b/packages/timeline/src/TimelineInput.ts
@@ -133,9 +133,7 @@ export class TimelineInput implements IPlugin {
             const value = changed[trackId]
 
             if (targetNode?.nodeType === 'shot') {
-              if (value) {
-                engine.fireShot(targetNodeId)
-              }
+              engine.fireShot(targetNodeId)
               continue
             }
 

--- a/packages/timeline/src/TimelineInput.ts
+++ b/packages/timeline/src/TimelineInput.ts
@@ -127,7 +127,8 @@ export class TimelineInput implements IPlugin {
           const paramValues: ParamValue[] = []
 
           for (const trackId of changedTrackIds) {
-            const targetNodeId = tracks.find((track) => track.id === trackId)?.targetNodeId ?? trackId
+            const targetNodeId =
+              tracks.find((track) => track.id === trackId)?.targetNodeId ?? trackId
             const targetNode = engine.getNode(targetNodeId)
             const value = changed[trackId]
 

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -84,20 +84,22 @@ export class TimelineManager {
 
   // Shot keyframes are momentary triggers, not held state: fire once whenever the number of
   // keyframes crossed (time <= position) increases since the last check.
-  private getShotFired(track: TimelineManagerTrack): boolean {
+  private getShouldShotFire(track: TimelineManagerTrack): true | undefined {
     const sorted = this.sortedKeyframesCache.get(track.id) ?? []
     const count = sorted.filter((kf) => kf.time <= this.position).length
     const lastCount = this.shotKeyframeCount.get(track.id) ?? 0
     this.shotKeyframeCount.set(track.id, count)
-    return count > lastCount
+    return count > lastCount ? true : undefined
   }
 
   private isShotTrack(track: TimelineManagerTrack): boolean {
     return track.trackType === 'keyframe' && track.keyframes[0]?.nodeType === 'shot'
   }
 
-  private getTrackValue(track: TimelineManagerKeyframeTrack): ParamValue | undefined {
-    return this.isShotTrack(track) ? this.getShotFired(track) : this.getHeldValue(track)
+  // Returns the value for a track at the current position, or undefined if no value is held.
+  // Also returns true for shot tracks if a shot should fire at the current position, or undefined if not.
+  private getTrackValue(track: TimelineManagerKeyframeTrack): ParamValue | true | undefined {
+    return this.isShotTrack(track) ? this.getShouldShotFire(track) : this.getHeldValue(track)
   }
 
   private computeValues(): TrackValues {

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -22,6 +22,8 @@ export class TimelineManager {
   private sortedKeyframesCache: Map<string, Keyframe[]> = new Map()
   private audioCache: Map<string, HTMLAudioElement> = new Map()
   private lastKeyframeIndex: Map<string, number> = new Map()
+  // Number of shot keyframes at or before the position as of the last check, per track.
+  private shotKeyframeCount: Map<string, number> = new Map()
   private clock: Clock | null = null
 
   constructor(timeline: TimelineManagerData, clock?: Clock) {
@@ -55,7 +57,7 @@ export class TimelineManager {
     this.lastKeyframeIndex.clear()
   }
 
-  private getTrackValue(track: TimelineManagerTrack): ParamValue | undefined {
+  private getHeldValue(track: TimelineManagerTrack): ParamValue | undefined {
     const sorted = this.sortedKeyframesCache.get(track.id) ?? []
     const startIndex = this.lastKeyframeIndex.get(track.id) ?? 0
     let value = startIndex > 0 ? sorted[startIndex - 1].value : undefined
@@ -67,6 +69,24 @@ export class TimelineManager {
     }
     this.lastKeyframeIndex.set(track.id, lastIndex)
     return value
+  }
+
+  // Shot keyframes are momentary triggers, not held state: fire once whenever the number of
+  // keyframes crossed (time <= position) increases since the last check.
+  private getShotFired(track: TimelineManagerTrack): boolean {
+    const sorted = this.sortedKeyframesCache.get(track.id) ?? []
+    const count = sorted.filter((kf) => kf.time <= this.position).length
+    const lastCount = this.shotKeyframeCount.get(track.id) ?? 0
+    this.shotKeyframeCount.set(track.id, count)
+    return count > lastCount
+  }
+
+  private isShotTrack(track: TimelineManagerTrack): boolean {
+    return track.trackType === 'keyframe' && track.keyframes[0]?.valueType === 'shot'
+  }
+
+  private getTrackValue(track: TimelineManagerTrack): ParamValue | undefined {
+    return this.isShotTrack(track) ? this.getShotFired(track) : this.getHeldValue(track)
   }
 
   private computeValues(): TrackValues {
@@ -82,9 +102,16 @@ export class TimelineManager {
 
   private getChangedValues(newValues: TrackValues): TrackValues {
     const changed: TrackValues = {}
-    for (const key of Object.keys(newValues)) {
-      if (this.cachedValues[key] !== newValues[key]) {
-        changed[key] = newValues[key]
+    for (const track of this.getAllTracks()) {
+      const value = newValues[track.id]
+      if (value === undefined) continue
+
+      // Shot fires are already edge-detected in getShotFired, so a `true` is forwarded as-is
+      // rather than compared against the last value (there's no "held state" to diff against).
+      if (this.isShotTrack(track)) {
+        if (value) changed[track.id] = value
+      } else if (this.cachedValues[track.id] !== value) {
+        changed[track.id] = value
       }
     }
     return changed

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -123,7 +123,7 @@ export class TimelineManager {
       // Shot fires are already edge-detected in getShotFired, so a `true` is forwarded as-is
       // rather than compared against the last value (there's no "held state" to diff against).
       if (this.isShotTrack(track)) {
-        if (value) changed[track.id] = value
+        changed[track.id] = value
       } else if (this.cachedValues[track.id] !== value) {
         changed[track.id] = value
       }

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -6,6 +6,7 @@ import type {
   Keyframe,
   TimelineManagerAudioTrack,
   TimelineManagerKeyframeTrack,
+  KeyframeParam,
 } from '@/types'
 
 export type TrackValues = Record<string, ParamValue>
@@ -59,7 +60,7 @@ export class TimelineManager {
   }
 
   private getHeldValue(track: TimelineManagerKeyframeTrack): ParamValue | undefined {
-    const sorted = this.sortedKeyframesCache.get(track.id) ?? []
+    const sorted = (this.sortedKeyframesCache.get(track.id) ?? []) as KeyframeParam[]
     const startIndex = this.lastKeyframeIndex.get(track.id) ?? 0
     let value = startIndex > 0 ? sorted[startIndex - 1].value : undefined
     let lastIndex = startIndex
@@ -92,10 +93,10 @@ export class TimelineManager {
   }
 
   private isShotTrack(track: TimelineManagerTrack): boolean {
-    return track.trackType === 'keyframe' && track.keyframes[0]?.valueType === 'shot'
+    return track.trackType === 'keyframe' && track.keyframes[0]?.nodeType === 'shot'
   }
 
-  private getTrackValue(track: TimelineManagerTrack): ParamValue | undefined {
+  private getTrackValue(track: TimelineManagerKeyframeTrack): ParamValue | undefined {
     return this.isShotTrack(track) ? this.getShotFired(track) : this.getHeldValue(track)
   }
 

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -86,7 +86,7 @@ export class TimelineManager {
   // keyframes crossed (time <= position) increases since the last check.
   private getShouldShotFire(track: TimelineManagerTrack): true | undefined {
     const sorted = this.sortedKeyframesCache.get(track.id) ?? []
-    const count = sorted.filter((kf) => kf.time <= this.position).length
+    const count = sorted.filter((kf) => kf.time < this.position).length
     const lastCount = this.shotKeyframeCount.get(track.id) ?? 0
     this.shotKeyframeCount.set(track.id, count)
     return count > lastCount ? true : undefined

--- a/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
+++ b/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
-import { HedronEngine, ParamNode } from '@hedron-gl/engine'
+import { HedronEngine } from '@hedron-gl/engine'
 import { useNodeOptionNodes } from '@hedron-gl/ui-core'
 import { DEFAULT_TIMELINE_ID } from '@/constants'
 import { TimelineManager } from '@/TimelineManager'
-import type { Keyframe, TimelineTrackInput } from '@/types'
+import type { Keyframe, KeyframeParam, TimelineTrackInput } from '@/types'
 
 interface UseTimelineHandlersParams {
   engine: HedronEngine
@@ -59,9 +59,8 @@ export const useTimelineHandlers = ({ engine, manager }: UseTimelineHandlersPara
 
       let keyframe: Keyframe
       if (targetNode.nodeType === 'shot') {
-        // Shot keyframes are momentary triggers; the value isn't used to decide firing.
-        keyframe = { id: crypto.randomUUID(), time, valueType: 'shot', value: true }
-      } else {
+        keyframe = { id: crypto.randomUUID(), time, nodeType: 'shot' }
+      } else if (targetNode.nodeType === 'param') {
         const targetParamValue = engine.getParamValue(inputNode.targetNodeId)
 
         if (targetParamValue === undefined) {
@@ -72,9 +71,14 @@ export const useTimelineHandlers = ({ engine, manager }: UseTimelineHandlersPara
         keyframe = {
           id: crypto.randomUUID(),
           time,
-          valueType: (targetNode as ParamNode).valueType,
+          valueType: targetNode.valueType,
           value: targetParamValue,
-        } as Keyframe
+          nodeType: 'param',
+        } as KeyframeParam
+      } else {
+        throw new Error(
+          `Unsupported target node type for input node ${inputNode.id} with type ${targetNode.nodeType}`,
+        )
       }
 
       const nextKeyframes: Keyframe[] = [...(inputNode.customData?.keyframes ?? []), keyframe].sort(

--- a/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
+++ b/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
@@ -50,25 +50,31 @@ export const useTimelineHandlers = ({ engine, manager }: UseTimelineHandlersPara
         return
       }
 
-      const targetParam = engine.getNode(inputNode.targetNodeId) as ParamNode | undefined
+      const targetNode = engine.getNode(inputNode.targetNodeId)
 
-      if (!targetParam) {
-        console.error(`Target param not found for input node ${inputNode.id}`)
+      if (!targetNode) {
+        console.error(`Target node not found for input node ${inputNode.id}`)
         return
       }
 
-      const targetParamValue = engine.getParamValue(inputNode.targetNodeId)
+      let keyframe: Keyframe
+      if (targetNode.nodeType === 'shot') {
+        // Shot keyframes are momentary triggers; the value isn't used to decide firing.
+        keyframe = { id: crypto.randomUUID(), time, valueType: 'shot', value: true }
+      } else {
+        const targetParamValue = engine.getParamValue(inputNode.targetNodeId)
 
-      if (targetParamValue === undefined) {
-        console.error(`Target param value not found for input node ${inputNode.id}`)
-        return
-      }
+        if (targetParamValue === undefined) {
+          console.error(`Target param value not found for input node ${inputNode.id}`)
+          return
+        }
 
-      const keyframe = {
-        id: crypto.randomUUID(),
-        time,
-        valueType: targetParam.valueType,
-        value: targetParamValue,
+        keyframe = {
+          id: crypto.randomUUID(),
+          time,
+          valueType: (targetNode as ParamNode).valueType,
+          value: targetParamValue,
+        }
       }
 
       const nextKeyframes: Keyframe[] = [...(inputNode.customData?.keyframes ?? []), keyframe].sort(

--- a/packages/timeline/src/stories/Timeline.stories.tsx
+++ b/packages/timeline/src/stories/Timeline.stories.tsx
@@ -8,6 +8,7 @@ import { TimelineManager } from '@/TimelineManager'
 import type { TrackValues } from '@/TimelineManager'
 import { Timeline } from '@/components/Timeline/Timeline'
 import type {
+  KeyframeParam,
   TimelineManagerData,
   TimelineManagerKeyframeTrack,
   TimelineManagerTrack,
@@ -55,10 +56,10 @@ export const WithKeyframes: Story = {
           label: 'Visibility',
           trackType: 'keyframe',
           keyframes: [
-            { id: 'kf-1', time: 1000, valueType: 'boolean', value: true },
-            { id: 'kf-2', time: 3000, valueType: 'boolean', value: false },
-            { id: 'kf-3', time: 5500, valueType: 'boolean', value: true },
-            { id: 'kf-4', time: 8000, valueType: 'boolean', value: false },
+            { id: 'kf-1', time: 1000, valueType: 'boolean', value: true, nodeType: 'param' },
+            { id: 'kf-2', time: 3000, valueType: 'boolean', value: false, nodeType: 'param' },
+            { id: 'kf-3', time: 5500, valueType: 'boolean', value: true, nodeType: 'param' },
+            { id: 'kf-4', time: 8000, valueType: 'boolean', value: false, nodeType: 'param' },
           ],
         },
       ],
@@ -82,9 +83,9 @@ export const WithVectorTrack: Story = {
               label: 'X',
               trackType: 'keyframe',
               keyframes: [
-                { id: 'kf-px-1', time: 1000, valueType: 'number', value: 0 },
-                { id: 'kf-px-2', time: 5000, valueType: 'number', value: 0.75 },
-                { id: 'kf-px-3', time: 9000, valueType: 'number', value: -0.2 },
+                { id: 'kf-px-1', time: 1000, valueType: 'number', value: 0, nodeType: 'param' },
+                { id: 'kf-px-2', time: 5000, valueType: 'number', value: 0.75, nodeType: 'param' },
+                { id: 'kf-px-3', time: 9000, valueType: 'number', value: -0.2, nodeType: 'param' },
               ],
             },
             {
@@ -92,9 +93,9 @@ export const WithVectorTrack: Story = {
               label: 'Y',
               trackType: 'keyframe',
               keyframes: [
-                { id: 'kf-py-1', time: 1500, valueType: 'number', value: -0.25 },
-                { id: 'kf-py-2', time: 4500, valueType: 'number', value: 0.5 },
-                { id: 'kf-py-3', time: 8000, valueType: 'number', value: 0.1 },
+                { id: 'kf-py-1', time: 1500, valueType: 'number', value: -0.25, nodeType: 'param' },
+                { id: 'kf-py-2', time: 4500, valueType: 'number', value: 0.5, nodeType: 'param' },
+                { id: 'kf-py-3', time: 8000, valueType: 'number', value: 0.1, nodeType: 'param' },
               ],
             },
           ],
@@ -128,9 +129,9 @@ export const Interactive = () => {
             label: 'X',
             trackType: 'keyframe',
             keyframes: [
-              { id: 'kf-px1', time: 500, valueType: 'number', value: -0.5 },
-              { id: 'kf-px2', time: 4000, valueType: 'number', value: 0.35 },
-              { id: 'kf-px3', time: 7000, valueType: 'number', value: 0.8 },
+              { id: 'kf-px1', time: 500, valueType: 'number', value: -0.5, nodeType: 'param' },
+              { id: 'kf-px2', time: 4000, valueType: 'number', value: 0.35, nodeType: 'param' },
+              { id: 'kf-px3', time: 7000, valueType: 'number', value: 0.8, nodeType: 'param' },
             ],
           },
           {
@@ -138,9 +139,9 @@ export const Interactive = () => {
             label: 'Y',
             trackType: 'keyframe',
             keyframes: [
-              { id: 'kf-py1', time: 1000, valueType: 'number', value: 0.25 },
-              { id: 'kf-py2', time: 5000, valueType: 'number', value: -0.1 },
-              { id: 'kf-py3', time: 8500, valueType: 'number', value: 0.55 },
+              { id: 'kf-py1', time: 1000, valueType: 'number', value: 0.25, nodeType: 'param' },
+              { id: 'kf-py2', time: 5000, valueType: 'number', value: -0.1, nodeType: 'param' },
+              { id: 'kf-py3', time: 8500, valueType: 'number', value: 0.55, nodeType: 'param' },
             ],
           },
         ],
@@ -150,9 +151,9 @@ export const Interactive = () => {
         label: 'Visibility',
         trackType: 'keyframe',
         keyframes: [
-          { id: 'kf-v1', time: 0, valueType: 'boolean', value: true },
-          { id: 'kf-v2', time: 3000, valueType: 'boolean', value: false },
-          { id: 'kf-v3', time: 6000, valueType: 'boolean', value: true },
+          { id: 'kf-v1', time: 0, valueType: 'boolean', value: true, nodeType: 'param' },
+          { id: 'kf-v2', time: 3000, valueType: 'boolean', value: false, nodeType: 'param' },
+          { id: 'kf-v3', time: 6000, valueType: 'boolean', value: true, nodeType: 'param' },
         ],
       },
       {
@@ -160,12 +161,12 @@ export const Interactive = () => {
         label: 'Strobe',
         trackType: 'keyframe',
         keyframes: [
-          { id: 'kf-s1', time: 1000, valueType: 'boolean', value: true },
-          { id: 'kf-s2', time: 2000, valueType: 'boolean', value: false },
-          { id: 'kf-s3', time: 4000, valueType: 'boolean', value: true },
-          { id: 'kf-s4', time: 5000, valueType: 'boolean', value: false },
-          { id: 'kf-s5', time: 7000, valueType: 'boolean', value: true },
-          { id: 'kf-s6', time: 8000, valueType: 'boolean', value: false },
+          { id: 'kf-s1', time: 1000, valueType: 'boolean', value: true, nodeType: 'param' },
+          { id: 'kf-s2', time: 2000, valueType: 'boolean', value: false, nodeType: 'param' },
+          { id: 'kf-s3', time: 4000, valueType: 'boolean', value: true, nodeType: 'param' },
+          { id: 'kf-s4', time: 5000, valueType: 'boolean', value: false, nodeType: 'param' },
+          { id: 'kf-s5', time: 7000, valueType: 'boolean', value: true, nodeType: 'param' },
+          { id: 'kf-s6', time: 8000, valueType: 'boolean', value: false, nodeType: 'param' },
         ],
       },
       {
@@ -173,8 +174,8 @@ export const Interactive = () => {
         label: 'Invert',
         trackType: 'keyframe',
         keyframes: [
-          { id: 'kf-i1', time: 2500, valueType: 'boolean', value: true },
-          { id: 'kf-i2', time: 7500, valueType: 'boolean', value: false },
+          { id: 'kf-i1', time: 2500, valueType: 'boolean', value: true, nodeType: 'param' },
+          { id: 'kf-i2', time: 7500, valueType: 'boolean', value: false, nodeType: 'param' },
         ],
       },
     ],
@@ -255,7 +256,7 @@ export const Interactive = () => {
       tracks: prev.tracks.map((track) => {
         const insertKeyframe = (track: TimelineManagerTrack): TimelineManagerTrack => {
           if (track.trackType === 'keyframe' && track.id === trackId) {
-            const lastKeyframe = track.keyframes[track.keyframes.length - 1]
+            const lastKeyframe = track.keyframes[track.keyframes.length - 1] as KeyframeParam
             const valueType = lastKeyframe?.valueType ?? 'boolean'
             const value =
               lastKeyframe?.value ??
@@ -361,11 +362,11 @@ export const LongDuration: Story = {
           label: 'Active',
           trackType: 'keyframe',
           keyframes: [
-            { id: 'kf-1', time: 10000, valueType: 'boolean', value: true },
-            { id: 'kf-2', time: 30000, valueType: 'boolean', value: false },
-            { id: 'kf-3', time: 60000, valueType: 'boolean', value: true },
-            { id: 'kf-4', time: 90000, valueType: 'boolean', value: false },
-            { id: 'kf-5', time: 110000, valueType: 'boolean', value: true },
+            { id: 'kf-1', time: 10000, valueType: 'boolean', value: true, nodeType: 'param' },
+            { id: 'kf-2', time: 30000, valueType: 'boolean', value: false, nodeType: 'param' },
+            { id: 'kf-3', time: 60000, valueType: 'boolean', value: true, nodeType: 'param' },
+            { id: 'kf-4', time: 90000, valueType: 'boolean', value: false, nodeType: 'param' },
+            { id: 'kf-5', time: 110000, valueType: 'boolean', value: true, nodeType: 'param' },
           ],
         },
       ],

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -4,7 +4,9 @@ export interface Keyframe {
   id: string
   time: number
   // TODO: This is a bit wonky because a keyframe could be typed with a non-matching valueType and value
-  valueType: ParamValueType
+  // 'shot' isn't a ParamValueType since shots aren't params - their keyframes are momentary
+  // triggers rather than held values.
+  valueType: ParamValueType | 'shot'
   value: ParamValue
 }
 

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -7,16 +7,26 @@ import {
 
 type KeyframeValueType = Exclude<ParamNonVectorValueType, null>
 
-type KeyframeForValueType<TValueType extends KeyframeValueType> = {
+type KeyframeBase = {
   id: string
   time: number
+}
+
+type KeyframeForValueType<TValueType extends KeyframeValueType> = KeyframeBase & {
+  nodeType: 'param'
   valueType: TValueType
   value: ParamForValueType<TValueType>['defaultValue']
 }
 
-export type Keyframe = {
+export type KeyframeParam = {
   [TValueType in KeyframeValueType]: KeyframeForValueType<TValueType>
 }[KeyframeValueType]
+
+export type KeyframeShot = KeyframeBase & {
+  nodeType: 'shot'
+}
+
+export type Keyframe = KeyframeParam | KeyframeShot
 
 /** Store node type for a timeline track */
 export type TimelineTrackInput = InputNode & {


### PR DESCRIPTION
- Keyframe.valueType widens to admit 'shot' alongside ParamValueType, since shots aren't params and their keyframes are momentary triggers rather than held values.
- TimelineManager: shot tracks are edge-detected via a per-track count of keyframes crossed (time <= position), separate from the existing held-value logic used for every other type. A shot fires once per forward crossing regardless of scrub direction or jump size, and never double-fires when sitting past a keyframe.
- useTimelineHandlers: inserting a keyframe on a shot-targeted track stores a constant `value: true` marker instead of reading a (nonexistent) param value.