### PR TITLE
Timeline: lerp for numeric keyframes, fix keyboard shortcuts stealing focus

### DIFF
--- a/packages/engine/src/store/types/ParamNode.ts
+++ b/packages/engine/src/store/types/ParamNode.ts
@@ -151,6 +151,7 @@ export type ParamValueType = ParamNode['valueType'] | null
 
 export type ParamVector = ParamVector2 | ParamVector3 | ParamRGB
 export type ParamVectorValueType = ParamVector['valueType']
+export type ParamNonVectorValueType = Exclude<ParamValueType, ParamVectorValueType>
 
 export type EnsureRequiredValueType<T> = T extends { valueType?: infer V }
   ? Omit<T, 'valueType'> & { valueType: V }

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -66,6 +66,22 @@ export class TimelineManager {
       lastIndex = i + 1
     }
     this.lastKeyframeIndex.set(track.id, lastIndex)
+
+    // 'number' params interpolate towards the next keyframe rather than holding until it's
+    // reached. Checked via valueType (not typeof value) since enum values can also be numbers,
+    // but represent discrete choices that shouldn't be interpolated between.
+    const current = sorted[lastIndex - 1]
+    const next = sorted[lastIndex]
+    if (
+      current?.valueType === 'number' &&
+      next &&
+      typeof current.value === 'number' &&
+      typeof next.value === 'number'
+    ) {
+      const t = (this.position - current.time) / (next.time - current.time)
+      return current.value + (next.value - current.value) * t
+    }
+
     return value
   }
 

--- a/packages/timeline/src/TimelineManager.ts
+++ b/packages/timeline/src/TimelineManager.ts
@@ -5,6 +5,7 @@ import type {
   TimelineManagerTrack,
   Keyframe,
   TimelineManagerAudioTrack,
+  TimelineManagerKeyframeTrack,
 } from '@/types'
 
 export type TrackValues = Record<string, ParamValue>
@@ -55,7 +56,7 @@ export class TimelineManager {
     this.lastKeyframeIndex.clear()
   }
 
-  private getTrackValue(track: TimelineManagerTrack): ParamValue | undefined {
+  private getTrackValue(track: TimelineManagerKeyframeTrack): ParamValue | undefined {
     const sorted = this.sortedKeyframesCache.get(track.id) ?? []
     const startIndex = this.lastKeyframeIndex.get(track.id) ?? 0
     let value = startIndex > 0 ? sorted[startIndex - 1].value : undefined
@@ -67,17 +68,10 @@ export class TimelineManager {
     }
     this.lastKeyframeIndex.set(track.id, lastIndex)
 
-    // 'number' params interpolate towards the next keyframe rather than holding until it's
-    // reached. Checked via valueType (not typeof value) since enum values can also be numbers,
-    // but represent discrete choices that shouldn't be interpolated between.
+    // interpolation for number values
     const current = sorted[lastIndex - 1]
     const next = sorted[lastIndex]
-    if (
-      current?.valueType === 'number' &&
-      next &&
-      typeof current.value === 'number' &&
-      typeof next.value === 'number'
-    ) {
+    if (current?.valueType === 'number' && next?.valueType === 'number') {
       const t = (this.position - current.time) / (next.time - current.time)
       return current.value + (next.value - current.value) * t
     }
@@ -88,6 +82,7 @@ export class TimelineManager {
   private computeValues(): TrackValues {
     const values: TrackValues = {}
     for (const track of this.getAllTracks()) {
+      if (track.trackType !== 'keyframe') continue
       const value = this.getTrackValue(track)
       if (value !== undefined) {
         values[track.id] = value
@@ -103,6 +98,7 @@ export class TimelineManager {
         changed[key] = newValues[key]
       }
     }
+
     return changed
   }
 

--- a/packages/timeline/src/components/Timeline/Timeline.tsx
+++ b/packages/timeline/src/components/Timeline/Timeline.tsx
@@ -66,6 +66,10 @@ export function Timeline({
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable) {
+        return
+      }
       if (e.key === 'x' && selectedKeyframes) {
         selectedKeyframes.forEach((keyframeId) => {
           onKeyframeDelete?.(keyframeId)

--- a/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
+++ b/packages/timeline/src/components/TimelineGlobalPanel/useTimelineHandlers.ts
@@ -69,7 +69,7 @@ export const useTimelineHandlers = ({ engine, manager }: UseTimelineHandlersPara
         time,
         valueType: targetParam.valueType,
         value: targetParamValue,
-      }
+      } as Keyframe
 
       const nextKeyframes: Keyframe[] = [...(inputNode.customData?.keyframes ?? []), keyframe].sort(
         (a, b) => a.time - b.time,

--- a/packages/timeline/src/stories/Timeline.stories.tsx
+++ b/packages/timeline/src/stories/Timeline.stories.tsx
@@ -263,6 +263,7 @@ export const Interactive = () => {
 
             return {
               ...track,
+              // @ts-ignore -- this is just a story file we don't need to care so much
               keyframes: [
                 ...track.keyframes,
                 {

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -1,12 +1,22 @@
-import { InputNode, CustomNode, ParamValueType, ParamValue } from '@hedron-gl/engine'
+import {
+  InputNode,
+  CustomNode,
+  ParamForValueType,
+  ParamNonVectorValueType,
+} from '@hedron-gl/engine'
 
-export interface Keyframe {
+type KeyframeValueType = Exclude<ParamNonVectorValueType, null>
+
+type KeyframeForValueType<TValueType extends KeyframeValueType> = {
   id: string
   time: number
-  // TODO: This is a bit wonky because a keyframe could be typed with a non-matching valueType and value
-  valueType: ParamValueType
-  value: ParamValue
+  valueType: TValueType
+  value: ParamForValueType<TValueType>['defaultValue']
 }
+
+export type Keyframe = {
+  [TValueType in KeyframeValueType]: KeyframeForValueType<TValueType>
+}[KeyframeValueType]
 
 /** Store node type for a timeline track */
 export type TimelineTrackInput = InputNode & {


### PR DESCRIPTION
- TimelineManager now interpolates between two keyframes for 'number' params instead of holding until the next one is reached. Discriminated by valueType (not typeof value) so numeric-backed enums correctly keep holding discretely instead of interpolating between option indices.
- Timeline's global keydown handler (i/x shortcuts) now ignores events when focus is on an input/textarea/contenteditable element, so typing "i" into a string param's text field no longer inserts a keyframe.