### PR TITLE
engine.renderer.requestFrame

### DIFF
--- a/apps/desktop/src/renderer/windows.ts
+++ b/apps/desktop/src/renderer/windows.ts
@@ -10,6 +10,7 @@ export const sendOutput = (display: Display): void => {
 
   outputWin.document.write('<div style="width:100vw;height:100vh;"></div>')
   outputWin.document.body.style.margin = '0'
+  outputWin.document.body.style.background = '#222'
   outputWin.document.body.style.cursor = 'none'
 
   const { x, y } = display.bounds
@@ -21,7 +22,7 @@ export const sendOutput = (display: Display): void => {
   })
 
   setTimeout(() => {
-    engine.setOutput(outputWin.document.querySelector('div') as HTMLDivElement)
+    engine.setOutput(outputWin.document.querySelector('div') as HTMLDivElement, outputWin)
   }, 1000)
 }
 

--- a/packages/engine/src/HedronEngine/HedronEngine.ts
+++ b/packages/engine/src/HedronEngine/HedronEngine.ts
@@ -551,8 +551,8 @@ export class HedronEngine {
     return this.renderer.createCanvas(containerEl)
   }
 
-  public setOutput(container: HTMLElement) {
-    this.renderer.setOutput(container)
+  public setOutput(container: HTMLElement, outputWindow: Window) {
+    this.renderer.setOutput(container, outputWindow)
   }
 
   public stopOutput() {
@@ -706,7 +706,7 @@ export class HedronEngine {
       }
 
       if (this.paused) {
-        requestAnimationFrame(loop)
+        this.renderer.requestFrame(loop)
         return
       }
 
@@ -723,7 +723,7 @@ export class HedronEngine {
 
       this.advanceFrame(deltaTime)
 
-      requestAnimationFrame(loop)
+      this.renderer.requestFrame(loop)
       this.onFrameEnd?.()
     }
 

--- a/packages/engine/src/world/Renderer.ts
+++ b/packages/engine/src/world/Renderer.ts
@@ -164,6 +164,10 @@ export class Renderer {
     this.aspectRatio = ratio
   }
 
+  /**
+   * Requests the next animation frame, making sure to match the refresh rate of the output window
+   * @param callback The function to call on the next animation frame.
+   */
   public requestFrame(callback: () => void): void {
     this.rafId = this.outputWindow.requestAnimationFrame(callback)
     this.frameCallback = callback

--- a/packages/engine/src/world/Renderer.ts
+++ b/packages/engine/src/world/Renderer.ts
@@ -17,12 +17,15 @@ export class Renderer {
   private outputContainer: HTMLElement | undefined | null
   private previewCanvas: HTMLCanvasElement | undefined
   private outputCanvas: HTMLCanvasElement | undefined
+  private outputWindow: Window = window
   private canvas: HTMLCanvasElement | undefined
   private previewContext: CanvasRenderingContext2D | undefined | null
   public aspectRatio: number = 1
   public passesNeedUpdate_webGPU: boolean = true
   private isSendingOutput = false
   private canvasSizeMode: CanvasSizeMode
+  private frameCallback: (() => void) | null = null
+  private rafId: number | null = null
 
   constructor({
     rendererType,
@@ -161,10 +164,16 @@ export class Renderer {
     this.aspectRatio = ratio
   }
 
+  public requestFrame(callback: () => void): void {
+    this.rafId = this.outputWindow.requestAnimationFrame(callback)
+    this.frameCallback = callback
+  }
+
   // Set the output to a second canvas (e.g. a separate window for making full screen)
-  public setOutput(container: HTMLElement): void {
+  public setOutput(container: HTMLElement, outputWindow: Window): void {
     this.stopOutput()
     this.outputContainer = container
+    this.outputWindow = outputWindow
 
     if (!this.outputContainer) throw new Error("Can't find container")
     if (!this.canvas) throw new Error("Can't find canvas")
@@ -202,10 +211,20 @@ export class Renderer {
     if (!this.canvas) throw new Error("Can't find canvas")
     if (!this.viewerContainer) throw new Error("Can't find viewerContainer")
 
+    this.outputWindow = window
     this.viewerContainer.innerHTML = ''
     this.canvas.setAttribute('style', '')
     this.viewerContainer.appendChild(this.canvas)
     this.isSendingOutput = false
+
+    // Keep frame loop going when switching back to the main window
+    if (this.frameCallback) {
+      if (this.rafId !== null) {
+        this.outputWindow.cancelAnimationFrame(this.rafId)
+      }
+      this.outputWindow.requestAnimationFrame(this.frameCallback)
+      this.frameCallback = null
+    }
 
     this.setSize()
   }

--- a/packages/engine/src/world/Renderer.ts
+++ b/packages/engine/src/world/Renderer.ts
@@ -215,6 +215,7 @@ export class Renderer {
     if (!this.canvas) throw new Error("Can't find canvas")
     if (!this.viewerContainer) throw new Error("Can't find viewerContainer")
 
+    const previousWindow = this.outputWindow
     this.outputWindow = window
     this.viewerContainer.innerHTML = ''
     this.canvas.setAttribute('style', '')
@@ -224,10 +225,9 @@ export class Renderer {
     // Keep frame loop going when switching back to the main window
     if (this.frameCallback) {
       if (this.rafId !== null) {
-        this.outputWindow.cancelAnimationFrame(this.rafId)
+        previousWindow.cancelAnimationFrame(this.rafId)
       }
-      this.outputWindow.requestAnimationFrame(this.frameCallback)
-      this.frameCallback = null
+      this.rafId = this.outputWindow.requestAnimationFrame(this.frameCallback)
     }
 
     this.setSize()


### PR DESCRIPTION
While working with the output window always open, I was noticing some stuttering in the output window, which wasn't happening in the preview canvas. It definitely got worse for more intense scenes, but was always much smoother in the preview canvas.

This was strange to me, because the preview canvas is actually copied pixels from the output window. The fps counter was always reporting a steady 60fps.

My theory on why this was happening is this:
- Each screen has its own refresh rate, even if they are both 60hz, they are not in sync
- We were using `window.requestAnimationFrame` for rendering, which was always tied to the window of the UI
- Once sending an output, we were rendering onto the output window while tied to the wrong window's refresh rate, causing some mismatch in when the render happens and the screen refreshes
- This wasn't always causing a visible issue, but at times when there was some drift away from the perfect frame rate, the output was suffering a lot more than the preview, which was always synced

The solution:
- Our engine's renderer now has a `requestFrame` method, rather than `window.requestAnimationFrame` 
- This is always making use of `outputWindow.requestAnimationFrame`, which is set based on whether we're sending to a separate window or not

This means that now when sending output, you may see stuttering in the preview canvas, which is the right place for that to happen, not what the audience sees! Maybe later we want an option to disable copying of pixels to the preview or throttle it to 30fps or something.

Probably needs some[ follow up work](https://github.com/nudibranchrecords/hedron/issues/672) but I'm merging for now due to visible improvements in stuttering