### PR TITLE
make hedron more touchscreen friendly

### DIFF
--- a/apps/desktop/src/main/SketchesServer/SketchesServer.ts
+++ b/apps/desktop/src/main/SketchesServer/SketchesServer.ts
@@ -83,6 +83,7 @@ export class SketchesServer extends EventEmitter {
         '.frag': 'text',
         '.vert': 'text',
         '.json': 'text',
+        '.md': 'text',
       },
       assetNames: '[dir]/[name]-[hash]',
       publicPath: `http://${HOST}:${port}`,

--- a/apps/desktop/src/renderer/components/App/App.tsx
+++ b/apps/desktop/src/renderer/components/App/App.tsx
@@ -89,6 +89,7 @@ const AppContent = (): JSX.Element => {
       <div
         className={c.handle}
         onMouseDown={onHandleMouseDown}
+        onTouchStart={onHandleMouseDown}
         role="separator"
         aria-orientation="vertical"
         tabIndex={0}

--- a/apps/desktop/src/renderer/components/App/useHandleDrag.ts
+++ b/apps/desktop/src/renderer/components/App/useHandleDrag.ts
@@ -15,26 +15,40 @@ export const useHandleDrag = () => {
   }
 
   useEffect(() => {
-    const onMouseMove = (e: MouseEvent) => {
+    const applyRatio = (clientX: number) => {
       if (!isDraggingRef.current) return
       const wrapper = wrapperRef.current
       if (!wrapper) return
       const rect = wrapper.getBoundingClientRect()
-      let ratio = (e.clientX - rect.left) / rect.width
+      let ratio = (clientX - rect.left) / rect.width
       ratio = Math.max(MIN_RATIO, Math.min(MAX_RATIO, ratio))
       setLeftRatio(ratio)
     }
-    const onMouseUp = () => {
+
+    const stopDragging = () => {
       if (isDraggingRef.current) {
         isDraggingRef.current = false
         clearGlobalCursor()
       }
     }
+
+    const onMouseMove = (e: MouseEvent) => applyRatio(e.clientX)
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return
+      applyRatio(e.touches[0].clientX)
+    }
+
     window.addEventListener('mousemove', onMouseMove)
-    window.addEventListener('mouseup', onMouseUp)
+    window.addEventListener('mouseup', stopDragging)
+    window.addEventListener('touchmove', onTouchMove)
+    window.addEventListener('touchend', stopDragging)
+    window.addEventListener('touchcancel', stopDragging)
     return () => {
       window.removeEventListener('mousemove', onMouseMove)
-      window.removeEventListener('mouseup', onMouseUp)
+      window.removeEventListener('mouseup', stopDragging)
+      window.removeEventListener('touchmove', onTouchMove)
+      window.removeEventListener('touchend', stopDragging)
+      window.removeEventListener('touchcancel', stopDragging)
     }
   }, [])
 

--- a/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
+++ b/packages/timeline/src/components/Timeline/usePlayheadScrub.ts
@@ -51,5 +51,5 @@ export const usePlayheadScrub = (
     }
   }, [onRulerMouseDown, playheadAreaRef])
 
-  useElementScrub(playheadAreaRef, onPlayheadAreaScrub, 'ew-resize')
+  useElementScrub(playheadAreaRef, onPlayheadAreaScrub, 'ew-resize', 'x')
 }

--- a/packages/ui-core/src/components/FloatSlider/FloatSlider.module.css
+++ b/packages/ui-core/src/components/FloatSlider/FloatSlider.module.css
@@ -25,7 +25,7 @@
   right: 0;
   z-index: 1;
   -webkit-tap-highlight-color: transparent;
-  touch-action: none;
+  touch-action: pan-y;
 }
 
 .numberInputContainer {

--- a/packages/ui-core/src/components/FloatSlider/FloatSlider.tsx
+++ b/packages/ui-core/src/components/FloatSlider/FloatSlider.tsx
@@ -150,7 +150,7 @@ export const FloatSlider = forwardRef<FloatSliderHandle, FloatSliderProps>(funct
     [range, min, max, direction, updateValue, onValueChange],
   )
 
-  useElementScrub(canvasRef, onElementScrub, 'ew-resize')
+  useElementScrub(canvasRef, onElementScrub, 'ew-resize', 'x')
 
   useEffect(() => {
     const canvas = canvasRef.current

--- a/packages/ui-core/src/components/NodeControl/NodeControl.module.css
+++ b/packages/ui-core/src/components/NodeControl/NodeControl.module.css
@@ -37,6 +37,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  min-height: 22px;
 }
 
 .inputCount {
@@ -55,7 +56,7 @@
 .title {
   flex: 1;
   min-width: 0;
-  padding: 3px;
+  padding: 6px 3px;
   display: flex;
   justify-content: space-between;
   height: auto;

--- a/packages/ui-core/src/components/NodeControl/NodeControl.tsx
+++ b/packages/ui-core/src/components/NodeControl/NodeControl.tsx
@@ -17,7 +17,7 @@ export const NodeControl = ({ isActive, children, onClick }: NodeControlProps) =
   const wasMouseDownOnInner = useWasMouseDownOnInnerContext()
 
   const handleClick = useCallback(() => {
-    // Disable click event if mouse down started on inner
+    // Disable click event if mouse/touch down started on inner
     if (!wasMouseDownOnInner.current) {
       onClick?.()
     }
@@ -75,15 +75,20 @@ export interface NodeControlInnerProps {
 }
 
 export const NodeControlInner = ({ children }: NodeControlInnerProps) => {
-  // Register mouse down on inner so click can be disabled if mouse is released outside of this component
-  const handleMouseDown = useMouseDownOnInner()
+  // Register mouse/touch down on inner so click can be disabled if mouse is released outside of this component
+  const { handleMouseDown, handleTouchStart } = useMouseDownOnInner()
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
   }, [])
 
   return (
-    <div className={c.inner} onClick={handleClick} onMouseDown={handleMouseDown}>
+    <div
+      className={c.inner}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
+    >
       {children}
     </div>
   )

--- a/packages/ui-core/src/components/NodeControl/wasMouseDownOnInner.tsx
+++ b/packages/ui-core/src/components/NodeControl/wasMouseDownOnInner.tsx
@@ -10,7 +10,7 @@ export const MouseDownContext = createContext<React.MutableRefObject<boolean> | 
 export const useWasMouseDownOnInnerContext = () => {
   const isMouseDown = useRef(false)
   useEffect(() => {
-    const handleDocumentMouseUp = () => {
+    const handleDocumentEnd = () => {
       if (isMouseDown) {
         // Wait for the next frame to set isMouseDown to false so the flag can be used in the click event
         requestAnimationFrame(() => {
@@ -19,10 +19,14 @@ export const useWasMouseDownOnInnerContext = () => {
       }
     }
 
-    document.addEventListener('mouseup', handleDocumentMouseUp)
+    document.addEventListener('mouseup', handleDocumentEnd)
+    document.addEventListener('touchend', handleDocumentEnd)
+    document.addEventListener('touchcancel', handleDocumentEnd)
 
     return () => {
-      document.removeEventListener('mouseup', handleDocumentMouseUp)
+      document.removeEventListener('mouseup', handleDocumentEnd)
+      document.removeEventListener('touchend', handleDocumentEnd)
+      document.removeEventListener('touchcancel', handleDocumentEnd)
     }
   }, [isMouseDown])
 
@@ -38,5 +42,11 @@ export const useMouseDownOnInner = () => {
     }
   }, [isMouseDownOnInner])
 
-  return handleMouseDown
+  const handleTouchStart = useCallback(() => {
+    if (isMouseDownOnInner) {
+      isMouseDownOnInner.current = true
+    }
+  }, [isMouseDownOnInner])
+
+  return { handleMouseDown, handleTouchStart }
 }

--- a/packages/ui-core/src/css/base.css
+++ b/packages/ui-core/src/css/base.css
@@ -9,6 +9,12 @@
     'opsz' 24;
 }
 
+html {
+  /* The app shell never pans or zooms as a whole; scrollable panels set their own
+     touch-action, so this only blocks stray pinch-zoom/double-tap-zoom gestures. */
+  touch-action: none;
+}
+
 body {
   user-select: none;
   margin: 0;

--- a/packages/ui-core/src/hooks/useElementScrub.tsx
+++ b/packages/ui-core/src/hooks/useElementScrub.tsx
@@ -1,13 +1,23 @@
 import { useEffect, useRef, type RefObject } from 'react'
 import { clearGlobalCursor, CursorCSSValue, setGlobalCursor } from '@utils/setGlobalCursor'
 
+// Touch movement (in screen px) before a gesture's axis is decided, for `axis` locked scrubs
+const AXIS_LOCK_THRESHOLD = 8
+
+type ScrubAxis = 'x' | 'y' | 'free'
+type GestureState = 'pending' | 'active' | 'cancelled'
+
 export const useElementScrub = (
   elRef: RefObject<HTMLElement>,
   onDrag: (delta: { x: number; y: number }) => void,
   cursorCSSValue?: CursorCSSValue,
+  axis: ScrubAxis = 'free',
 ) => {
   const startX = useRef<number>(0)
   const startY = useRef<number>(0)
+  // Only used on touch: lets a vertical (or horizontal) swipe fall through to native
+  // scrolling instead of being captured as a drag, when `axis` locks this scrub to one axis.
+  const gestureState = useRef<GestureState>('active')
 
   useEffect(() => {
     const el = elRef.current
@@ -63,6 +73,7 @@ export const useElementScrub = (
     const handleTouchStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) return
 
+      gestureState.current = axis === 'free' ? 'active' : 'pending'
       start(e.touches[0].screenX, e.touches[0].screenY)
 
       document.addEventListener('touchmove', onTouchMove)
@@ -72,7 +83,32 @@ export const useElementScrub = (
 
     const onTouchMove = (e: TouchEvent) => {
       if (e.touches.length !== 1) return
-      move(e.touches[0].screenX, e.touches[0].screenY)
+
+      const { screenX: x, screenY: y } = e.touches[0]
+
+      if (gestureState.current === 'cancelled') return
+
+      if (gestureState.current === 'pending') {
+        const diffX = x - startX.current
+        const diffY = y - startY.current
+
+        if (Math.max(Math.abs(diffX), Math.abs(diffY)) < AXIS_LOCK_THRESHOLD) return
+
+        // Gesture moved mostly along the axis we don't own (e.g. a vertical scroll
+        // swipe crossing a horizontal slider) - bail out and let it scroll natively.
+        const isCrossAxis =
+          (axis === 'x' && Math.abs(diffY) > Math.abs(diffX)) ||
+          (axis === 'y' && Math.abs(diffX) > Math.abs(diffY))
+
+        if (isCrossAxis) {
+          gestureState.current = 'cancelled'
+          return
+        }
+
+        gestureState.current = 'active'
+      }
+
+      move(x, y)
     }
 
     const onTouchEnd = () => {


### PR DESCRIPTION
Makes hedron more touchscreen friendly
- Nodes can be tapped to display children/add inputs
- Wont grab slider handles when scrolling vertically
- Can grab the middle divider 

https://github.com/user-attachments/assets/687be007-4579-4035-a94b-0b4fd8ceb3ca